### PR TITLE
fix: start-safe hand-off never completes under Cloud Run startup probe

### DIFF
--- a/start-safe.js
+++ b/start-safe.js
@@ -95,18 +95,21 @@ async function bootstrap() {
     console.log("--- [STEP 3/3] STARTING APPLICATION SERVER ---");
     startupState = "handoff";
 
-    server.close((closeError) => {
-      if (closeError) {
-        console.error("Failed to close bootstrap server:", closeError);
-        startupState = "failed";
-        startupError = closeError.message;
-        process.exit(1);
-        return;
-      }
+    // Force-close all active connections (Cloud Run's startup probe keeps one
+    // alive, which would otherwise block server.close from completing).
+    if (typeof server.closeAllConnections === "function") {
+      server.closeAllConnections();
+    }
 
-      startupState = "starting-app";
-      require("./server.js");
+    await new Promise((resolve, reject) => {
+      server.close((closeError) => {
+        if (closeError) return reject(closeError);
+        resolve();
+      });
     });
+
+    startupState = "starting-app";
+    require("./server.js");
   } catch (error) {
     startupState = "failed";
     startupError = error.message;


### PR DESCRIPTION
## The bug

\`start-safe.js\` hands off to \`server.js\` via:

\`\`\`js
server.close((closeError) => {
  ...
  require("./server.js");
});
\`\`\`

\`server.close(callback)\` only fires the callback once **every active connection has ended**. Cloud Run's startup probe holds a keep-alive connection open continuously, so the callback never fires, \`require("./server.js")\` is never reached, and the bootstrap Express app (which only knows \`/health/simple\`) keeps serving traffic.

## Observable symptoms

\`\`\`
GET /          -> 404 "Cannot GET /"
GET /health    -> 404 "Cannot GET /"
GET /mcp       -> 404 "Cannot GET /"
GET /llms.txt  -> 404 "Cannot GET /"
GET /health/simple -> 200   ← only this works (bootstrap handles it)
\`\`\`

Logs show \`Server listening on http://0.0.0.0:8080\` from server.js, but it's from a different container instance that briefly got traffic before being SIGTERMed. New cold-starts get stuck in the bootstrap because connections never drain.

## Fix

Call \`server.closeAllConnections()\` (Node 18.2+) before awaiting \`server.close\`. This severs existing sockets immediately so \`server.close\` can complete and \`require("./server.js")\` can run.

## Why it worked before

Recent main went through two successful startups (revisions 33 and 34 both showed \`Server listening\` logs). My guess: when the bootstrap had no active traffic yet, the close callback fired instantly. The bug manifests consistently now that the service is under steady probe pressure.

## Test plan

- [ ] Cloud Build succeeds
- [ ] After redeploy: \`GET /\` serves the landing page HTML
- [ ] \`GET /health\` returns 200
- [ ] \`GET /mcp\` returns 401 (missing key) instead of 404
- [ ] \`GET /llms.txt\` returns the docs
- [ ] \`GET /.well-known/mcp.json\` returns the discovery JSON