### PR TITLE
fix: migrate Gemini defaults off deprecated 1.5 models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,8 @@ MIXPANEL_PROJECT_TOKEN=your_mixpanel_token_here
 # ================================
 # Used by enrichment service and AI query; Gemini is primary in code
 GEMINI_API_KEY=your_gemini_api_key_here
-# GEMINI_MODEL_PRO=gemini-1.5-pro
-# GEMINI_MODEL_FLASH=gemini-1.5-flash
+# GEMINI_MODEL_PRO=gemini-2.5-pro
+# GEMINI_MODEL_FLASH=gemini-2.5-flash
 # Enable AI-enhanced lead scoring (requires GEMINI_API_KEY)
 # ENABLE_AI_LEAD_SCORING=true
 

--- a/setup-env.js
+++ b/setup-env.js
@@ -58,15 +58,15 @@ const envConfig = {
     },
     {
       key: "GEMINI_MODEL_PRO",
-      description: "Gemini Pro model name (default: gemini-1.5-pro)",
+      description: "Gemini Pro model name (default: gemini-2.5-pro)",
       category: "AI Enrichment",
-      default: "gemini-1.5-pro",
+      default: "gemini-2.5-pro",
     },
     {
       key: "GEMINI_MODEL_FLASH",
-      description: "Gemini Flash model name (default: gemini-1.5-flash)",
+      description: "Gemini Flash model name (default: gemini-2.5-flash)",
       category: "AI Enrichment",
-      default: "gemini-1.5-flash",
+      default: "gemini-2.5-flash",
     },
     {
       key: "ENABLE_AI_LEAD_SCORING",

--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -24,8 +24,8 @@ class GeminiService {
     this.genAI = new GoogleGenerativeAI(apiKey);
     
     // Model configuration
-    this.modelPro = process.env.GEMINI_MODEL_PRO || "gemini-1.5-pro";
-    this.modelFlash = process.env.GEMINI_MODEL_FLASH || "gemini-1.5-flash";
+    this.modelPro = process.env.GEMINI_MODEL_PRO || "gemini-2.5-pro";
+    this.modelFlash = process.env.GEMINI_MODEL_FLASH || "gemini-2.5-flash";
     
     // Cost tracking (approximate costs per 1000 operations in USD)
     // Gemini pricing: Pro ~$1.25/1M input tokens, $5/1M output tokens


### PR DESCRIPTION
Gemini 1.5 Pro/Flash are deprecated and being retired; they no longer appear in the live models list for our API key. Bumps the env-default fallbacks (env overrides still win):

- `gemini-1.5-pro` -> `gemini-2.5-pro`
- `gemini-1.5-flash` -> `gemini-2.5-flash`

Touches .env.example, setup-env.js, and geminiService.js defaults only. 2.5 chosen over 3.x as the cheapest stable GA equivalent (no cost increase).