### PR TITLE
feat: prod-ready hardening (auth, rate limits, webhook retries)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,19 @@ PORT=8080
 NODE_ENV=development
 LOG_LEVEL=info
 
+# Auth
+# In production (NODE_ENV=production) write keys are required — no bootstrap.
+# Force the same behavior in any env:
+# CAIRO_REQUIRE_WRITE_KEYS=true
+
+# Rate limiting (per write key)
+# CAIRO_RATE_LIMIT=120
+# CAIRO_RATE_WINDOW_MS=60000
+
+# Agent webhook push retries
+# CAIRO_WEBHOOK_RETRIES=3
+# CAIRO_WEBHOOK_RETRY_DELAY_MS=250
+
 # Optional: Sentry
 # SENTRY_DSN=
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Open-source, agent-first event tracking. Agents are the primary user. Track even
 
 Cairo does **not** connect to messaging gateways itself.
 
+> **Status:** dogfood / early production. Self-host from git. npm packages (`@cairo/*`) are not published yet.
+
 ## Why Cairo
 
 - **MCP-first.** Agents connect via Model Context Protocol. Tools for events, identity, errors, notification handoff, and GDPR.
@@ -11,7 +13,21 @@ Cairo does **not** connect to messaging gateways itself.
 - **Agent handoff.** Rules enqueue notifications for agents (pull via MCP or push via webhook). Agents relay through whatever gateway they already use.
 - **Self-hosted.** Node.js + PostgreSQL. Your data stays on your infrastructure.
 
-## Quick Start
+## Quick Start (self-host)
+
+```bash
+git clone https://github.com/outcome-driven-studio/cairo.git
+cd cairo
+cp .env.example .env.local
+# set POSTGRES_URL in .env.local
+
+npm install
+npm run migrate
+node bin/cairo.js create-write-key --name local   # prints a key — save it
+npm start
+```
+
+Production tip: set `NODE_ENV=production` (or `CAIRO_REQUIRE_WRITE_KEYS=true`) so bootstrap mode is disabled and only real keys work.
 
 ### For Agents (MCP)
 
@@ -20,24 +36,28 @@ HTTP MCP against a running Cairo instance:
 ```bash
 curl -X POST https://your-cairo.com/mcp \
   -H "Content-Type: application/json" \
-  -H "X-Write-Key: your-write-key" \
+  -H "X-Write-Key: YOUR_KEY" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
     "name":"track_event",
     "arguments":{"event":"signup","user_id":"user_123","properties":{"plan":"free"}}
   }}'
 ```
 
-Agent self-reporting via stdio MCP (local package until published):
+Agent self-reporting via stdio MCP (from this repo until packages are published):
+
+```bash
+cd packages/agent-mcp && npm install && npm run build
+```
 
 ```json
 {
   "mcpServers": {
     "cairo-agent": {
       "command": "node",
-      "args": ["./packages/agent-mcp/dist/index.js"],
+      "args": ["/absolute/path/to/cairo/packages/agent-mcp/dist/index.js"],
       "env": {
         "CAIRO_HOST": "https://your-cairo-instance.com",
-        "CAIRO_WRITE_KEY": "your-write-key",
+        "CAIRO_WRITE_KEY": "YOUR_KEY",
         "CAIRO_AGENT_ID": "my-agent"
       }
     }
@@ -47,16 +67,19 @@ Agent self-reporting via stdio MCP (local package until published):
 
 ### For Apps (SDK)
 
+Packages are not on npm yet. Install from git/workspace:
+
 ```bash
-npm install @cairo/tracker
-# or until published: file:packages/tracker
+# from this monorepo
+cd packages/tracker && npm install && npm run build
+npm install /absolute/path/to/cairo/packages/tracker
 ```
 
 ```typescript
 import { Cairo } from '@cairo/tracker';
 
 const cairo = Cairo.init({
-  writeKey: 'your-write-key',
+  writeKey: 'YOUR_KEY',
   host: 'https://your-cairo-instance.com',
 });
 
@@ -70,7 +93,7 @@ cairo.identify({
   userId: 'user_123',
   traits: {
     email: 'ava@school.edu',
-    telegram_chat_id: '123456789', // stored for agents to look up when relaying
+    telegram_chat_id: '123456789', // for agents to look up when relaying
   },
 });
 
@@ -119,6 +142,7 @@ Agent loop:
 | **Errors** | `capture_error`, `list_error_groups`, `get_error_group`, `resolve_error`, `error_trends` |
 | **Notifications** | `set_user_channel`, `create_notification_rule`, `list_notification_rules`, `delete_notification_rule`, `enqueue_notification`, `get_pending_notifications`, `ack_notification`, `register_agent_webhook` |
 | **GDPR** | `gdpr_delete_user`, `gdpr_suppress_user`, `gdpr_unsuppress_user`, `gdpr_check_suppression` |
+| **Auth** | `create_write_key`, `list_write_keys`, `revoke_write_key` |
 | **Agents** | `query_agent_sessions` |
 | **System** | `system_health`, `describe_tool` |
 
@@ -138,23 +162,15 @@ All require `X-Write-Key` (or `Authorization: Bearer`).
 | * | `/v2/errors/*` | Error tracking |
 | * | `/v2/agent/*` | Agent sessions |
 
-## Setup
+## Ops
 
 ```bash
-cp .env.example .env.local
-# set POSTGRES_URL
-npm install
-npm run migrate
-npm start
+node bin/cairo.js create-write-key --name prod
+node bin/cairo.js list-write-keys
+node bin/cairo.js revoke-write-key --id <id>
 ```
 
-Insert a write key once the DB is up:
-
-```sql
-INSERT INTO write_keys (key, name) VALUES ('dev-key', 'local');
-```
-
-Until at least one write key exists, any non-empty key is accepted (bootstrap mode).
+Useful env vars: see [`.env.example`](./.env.example). Rate limit defaults to 120 req/min per write key. Agent webhook push retries 3 times with backoff (`CAIRO_WEBHOOK_RETRIES`).
 
 ## License
 

--- a/bin/cairo.js
+++ b/bin/cairo.js
@@ -1,24 +1,23 @@
 #!/usr/bin/env node
 
-const args = process.argv.slice(2);
+const { loadEnv } = require('../src/utils/envLoader');
+loadEnv();
 
-// Parse flags
+const args = process.argv.slice(2);
+const command = args.find((a) => !a.startsWith('-'));
 const flags = {};
+
 for (let i = 0; i < args.length; i++) {
-  if (args[i] === '--port' || args[i] === '-p') {
-    flags.port = args[++i];
-  } else if (args[i] === '--help' || args[i] === '-h') {
-    flags.help = true;
-  } else if (args[i] === '--version' || args[i] === '-v') {
-    flags.version = true;
-  } else if (args[i] === 'migrate') {
-    flags.migrate = true;
-  }
+  if (args[i] === '--port' || args[i] === '-p') flags.port = args[++i];
+  else if (args[i] === '--help' || args[i] === '-h') flags.help = true;
+  else if (args[i] === '--version' || args[i] === '-v') flags.version = true;
+  else if (args[i] === '--name' || args[i] === '-n') flags.name = args[++i];
+  else if (args[i] === '--key') flags.key = args[++i];
+  else if (args[i] === '--id') flags.id = args[++i];
 }
 
 if (flags.version) {
-  const pkg = require('../package.json');
-  console.log(pkg.version);
+  console.log(require('../package.json').version);
   process.exit(0);
 }
 
@@ -29,48 +28,87 @@ cairo - Agent-first event tracking
 Usage:
   cairo [options]
   cairo migrate
+  cairo create-write-key [--name <name>] [--key <value>]
+  cairo list-write-keys
+  cairo revoke-write-key --id <id-or-key>
 
 Options:
-  --port, -p <port>   Port to listen on (default: 8080, or PORT env var)
-  --help, -h          Show this help
-  --version, -v       Show version
+  --port, -p <port>   Port to listen on (default: 8080)
+  --help, -h
+  --version, -v
 
-Commands:
-  migrate             Run database migrations
-
-Environment variables:
-  PORT                Server port (default: 8080)
-  POSTGRES_URL        PostgreSQL connection string (required)
-  SENTRY_DSN          Optional Sentry DSN
-  CAIRO_ERROR_AGENT_ID  Optional agent id to receive error handoffs
-
-MCP protocol:
-  POST /mcp           JSON-RPC endpoint for agents
-  GET  /mcp           Discovery (server info + tools list)
-  GET  /llms.txt      Agent-readable documentation
+Environment:
+  POSTGRES_URL              PostgreSQL connection string (required)
+  NODE_ENV=production       Enforce write keys (no bootstrap)
+  CAIRO_REQUIRE_WRITE_KEYS  Force write-key enforcement in any env
+  CAIRO_RATE_LIMIT          Requests per window (default 120)
+  CAIRO_RATE_WINDOW_MS      Window size ms (default 60000)
+  CAIRO_WEBHOOK_RETRIES     Agent webhook push retries (default 3)
 
 Examples:
-  npx cairo --port 3000
-  npx cairo migrate
-  POSTGRES_URL=postgres://... npx cairo
+  POSTGRES_URL=postgres://... npx cairo migrate
+  POSTGRES_URL=postgres://... npx cairo create-write-key --name prod
+  POSTGRES_URL=postgres://... npx cairo --port 8080
 `);
   process.exit(0);
 }
 
-// Apply flags to env before loading server
 if (flags.port) process.env.PORT = flags.port;
 
-if (flags.migrate) {
+async function withDb(fn) {
+  const db = require('../src/utils/db');
+  try {
+    await fn();
+  } finally {
+    try { await db.close(); } catch (_) { /* */ }
+  }
+}
+
+if (command === 'migrate') {
   const { runMigrations } = require('../src/migrations/run_migrations');
   runMigrations()
-    .then(() => {
-      console.log('Migrations completed successfully.');
-      process.exit(0);
-    })
-    .catch((err) => {
-      console.error('Migration failed:', err.message);
+    .then(() => { console.log('Migrations completed successfully.'); process.exit(0); })
+    .catch((err) => { console.error('Migration failed:', err.message); process.exit(1); });
+} else if (command === 'create-write-key') {
+  withDb(async () => {
+    const { createWriteKey } = require('../src/middleware/auth');
+    const row = await createWriteKey({ name: flags.name || 'default', key: flags.key });
+    console.log('Write key created:');
+    console.log(`  id:   ${row.id}`);
+    console.log(`  name: ${row.name}`);
+    console.log(`  key:  ${row.key}`);
+    console.log('\nStore this key securely — it is shown only once in full.');
+  }).then(() => process.exit(0)).catch((e) => { console.error(e.message); process.exit(1); });
+} else if (command === 'list-write-keys') {
+  withDb(async () => {
+    const { listWriteKeys } = require('../src/middleware/auth');
+    const rows = await listWriteKeys();
+    if (!rows.length) {
+      console.log('No write keys. Create one with: cairo create-write-key --name prod');
+      return;
+    }
+    for (const r of rows) {
+      const status = r.revoked_at ? `revoked@${r.revoked_at.toISOString?.() || r.revoked_at}` : 'active';
+      console.log(`${r.id}  ${r.key_prefix}  ${r.name || '-'}  ${status}`);
+    }
+  }).then(() => process.exit(0)).catch((e) => { console.error(e.message); process.exit(1); });
+} else if (command === 'revoke-write-key') {
+  if (!flags.id) {
+    console.error('--id <id-or-key> required');
+    process.exit(1);
+  }
+  withDb(async () => {
+    const { revokeWriteKey } = require('../src/middleware/auth');
+    const row = await revokeWriteKey(flags.id);
+    if (!row) {
+      console.error('Key not found or already revoked');
       process.exit(1);
-    });
+    }
+    console.log(`Revoked: ${row.id} (${row.name || 'unnamed'})`);
+  }).then(() => process.exit(0)).catch((e) => { console.error(e.message); process.exit(1); });
+} else if (command) {
+  console.error(`Unknown command: ${command}. Try --help`);
+  process.exit(1);
 } else {
   require('../server');
 }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,31 @@
+# Publishing @cairo packages (when ready)
+
+Packages live under `packages/` and are **not published to npm yet**.
+
+## Prerequisites
+
+1. Create an npm organization named `cairo` (or change package names).
+2. `npm login` with an account that can publish public scoped packages.
+3. Each package already has `"publishConfig": { "access": "public" }`.
+
+## Build & publish
+
+```bash
+# from repo root
+npm install
+npm run build
+
+# publish each package (version bump first)
+cd packages/tracker && npm version patch && npm publish --access public
+cd ../agent-tracker && npm version patch && npm publish --access public
+cd ../agent-mcp && npm version patch && npm publish --access public
+```
+
+Until then, consumers should install from git/path as documented in the root README.
+
+## Root server package
+
+Root `package.json` is named `cairo` (v3). Publishing it would conflict with the unrelated existing `cairo` package on npm (`0.1.0-alpha.3`). Prefer:
+
+- Distribute the server via git + Docker, or
+- Publish as `@cairo/server` / `cairo-cdp` after renaming

--- a/llms.txt
+++ b/llms.txt
@@ -58,6 +58,11 @@ JSON-RPC 2.0. Methods: initialize, tools/list, tools/call, ping.
 - gdpr_unsuppress_user { user_id, namespace? }
 - gdpr_check_suppression { user_id, namespace? }
 
+### Auth
+- create_write_key { name?, key? }
+- list_write_keys {}
+- revoke_write_key { id }
+
 ### Agents / System
 - query_agent_sessions { agent_id?, limit?, namespace? }
 - system_health {}
@@ -70,8 +75,13 @@ JSON-RPC 2.0. Methods: initialize, tools/list, tools/call, ping.
 - /v2/errors/* — error tracking
 - /v2/agent/* — agent sessions
 
+## Auth notes
+- Pass X-Write-Key or Authorization: Bearer on every /mcp and /v2 request
+- NODE_ENV=production or CAIRO_REQUIRE_WRITE_KEYS=true disables bootstrap
+- Create keys: CLI `cairo create-write-key --name prod` or MCP create_write_key
+
 ## Typical agent relay loop
 1. create_notification_rule targeting your agent_id
-2. Events arrive → Cairo enqueues pending notifications (and optional webhook push)
+2. Events arrive → Cairo enqueues pending notifications (webhook push retries on failure)
 3. get_pending_notifications → relay via your gateway using payload.channels
 4. ack_notification

--- a/packages/README.md
+++ b/packages/README.md
@@ -8,29 +8,19 @@
 
 All packages post to `${host}/v2/batch` (also available as `/api/v2/batch`).
 
-**Not yet published to npm.** Build locally:
+**Not yet published to npm.** See [docs/PUBLISHING.md](../docs/PUBLISHING.md).
+
+Build locally:
 
 ```bash
 npm install
 npm run build
 ```
 
-Until published, point MCP configs at the local package:
+Install from path:
 
-```json
-{
-  "mcpServers": {
-    "cairo-agent": {
-      "command": "node",
-      "args": ["./packages/agent-mcp/dist/index.js"],
-      "env": {
-        "CAIRO_HOST": "http://localhost:8080",
-        "CAIRO_WRITE_KEY": "your-key",
-        "CAIRO_AGENT_ID": "my-agent"
-      }
-    }
-  }
-}
+```bash
+npm install /path/to/cairo/packages/tracker
 ```
 
-For the server's full MCP tool surface (events, notifications, GDPR, etc.), connect to `POST /mcp` on a running Cairo instance — that is separate from `@cairo/agent-mcp`.
+For the server's full MCP tool surface (events, notifications, GDPR, write keys), connect to `POST /mcp` on a running Cairo instance — that is separate from `@cairo/agent-mcp`.

--- a/server.js
+++ b/server.js
@@ -57,6 +57,9 @@ app.get('/health/detailed', async (req, res) => {
 app.use(express.json({ limit: '2mb' }));
 app.use(express.urlencoded({ extended: true }));
 
+const { rateLimit } = require('./src/middleware/rateLimit');
+app.use(rateLimit);
+
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const { query } = require('../utils/db');
 const logger = require('../utils/logger');
 
@@ -5,16 +6,22 @@ const logger = require('../utils/logger');
  * Validate write key against the write_keys table.
  * Accepts X-Write-Key header or Authorization: Bearer <key>.
  *
- * Bootstrap: if write_keys table is empty (or missing), any non-empty key
- * is accepted so first-run setup is not locked out. Once at least one key
- * exists, validation is enforced.
+ * Bootstrap (dev only): if write_keys is empty, any non-empty key is accepted
+ * unless NODE_ENV=production or CAIRO_REQUIRE_WRITE_KEYS=true.
  */
-let _cache = { keys: new Set(), loadedAt: 0 };
-const CACHE_TTL_MS = 60_000;
+let _cache = { keys: new Set(), loadedAt: 0, empty: true };
+const CACHE_TTL_MS = 30_000;
+
+function requireKeysEnforced() {
+  return (
+    process.env.CAIRO_REQUIRE_WRITE_KEYS === 'true' ||
+    process.env.NODE_ENV === 'production'
+  );
+}
 
 async function loadWriteKeys() {
   const now = Date.now();
-  if (now - _cache.loadedAt < CACHE_TTL_MS && _cache.keys.size >= 0) {
+  if (now - _cache.loadedAt < CACHE_TTL_MS) {
     return _cache;
   }
   try {
@@ -27,7 +34,6 @@ async function loadWriteKeys() {
       empty: result.rows.length === 0,
     };
   } catch (err) {
-    // Table may not exist yet during first boot
     logger.warn('[auth] write_keys lookup failed:', err.message);
     _cache = { keys: new Set(), loadedAt: now, empty: true, error: true };
   }
@@ -42,6 +48,41 @@ function extractWriteKey(req) {
   );
 }
 
+function generateWriteKey() {
+  return `ck_${crypto.randomBytes(24).toString('hex')}`;
+}
+
+async function createWriteKey({ name = 'default', key } = {}) {
+  const value = key || generateWriteKey();
+  const result = await query(
+    `INSERT INTO write_keys (key, name) VALUES ($1, $2) RETURNING id, key, name, created_at`,
+    [value, name]
+  );
+  invalidateWriteKeyCache();
+  return result.rows[0];
+}
+
+async function listWriteKeys() {
+  const result = await query(
+    `SELECT id, name, created_at, revoked_at,
+            LEFT(key, 8) || '…' AS key_prefix
+     FROM write_keys
+     ORDER BY created_at DESC`
+  );
+  return result.rows;
+}
+
+async function revokeWriteKey(idOrKey) {
+  const result = await query(
+    `UPDATE write_keys SET revoked_at = NOW()
+     WHERE (id::text = $1 OR key = $1) AND revoked_at IS NULL
+     RETURNING id, name, revoked_at`,
+    [idOrKey]
+  );
+  invalidateWriteKeyCache();
+  return result.rows[0] || null;
+}
+
 async function requireWriteKey(req, res, next) {
   const writeKey = extractWriteKey(req);
 
@@ -53,9 +94,16 @@ async function requireWriteKey(req, res, next) {
   }
 
   const cache = await loadWriteKeys();
+  const enforced = requireKeysEnforced();
 
-  // Bootstrap / fail-open when no keys configured yet
   if (cache.empty) {
+    if (enforced) {
+      return res.status(401).json({
+        success: false,
+        error:
+          'No write keys configured. Run: npx cairo create-write-key --name production',
+      });
+    }
     req.writeKey = writeKey;
     return next();
   }
@@ -71,7 +119,6 @@ async function requireWriteKey(req, res, next) {
   next();
 }
 
-/** MCP variant — JSON-RPC error shape */
 async function requireWriteKeyMcp(req, res, next) {
   const writeKey = extractWriteKey(req);
 
@@ -87,7 +134,24 @@ async function requireWriteKeyMcp(req, res, next) {
   }
 
   const cache = await loadWriteKeys();
-  if (!cache.empty && !cache.keys.has(writeKey)) {
+  const enforced = requireKeysEnforced();
+
+  if (cache.empty) {
+    if (enforced) {
+      return res.status(401).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32000,
+          message: 'No write keys configured. Run: npx cairo create-write-key',
+        },
+      });
+    }
+    req.writeKey = writeKey;
+    return next();
+  }
+
+  if (!cache.keys.has(writeKey)) {
     return res.status(401).json({
       jsonrpc: '2.0',
       id: null,
@@ -100,7 +164,7 @@ async function requireWriteKeyMcp(req, res, next) {
 }
 
 function invalidateWriteKeyCache() {
-  _cache = { keys: new Set(), loadedAt: 0 };
+  _cache = { keys: new Set(), loadedAt: 0, empty: true };
 }
 
 module.exports = {
@@ -109,4 +173,9 @@ module.exports = {
   extractWriteKey,
   invalidateWriteKeyCache,
   loadWriteKeys,
+  createWriteKey,
+  listWriteKeys,
+  revokeWriteKey,
+  generateWriteKey,
+  requireKeysEnforced,
 };

--- a/src/middleware/rateLimit.js
+++ b/src/middleware/rateLimit.js
@@ -1,0 +1,77 @@
+/**
+ * Simple in-memory per-write-key rate limiter.
+ * Env: CAIRO_RATE_LIMIT (requests per window, default 120)
+ *      CAIRO_RATE_WINDOW_MS (default 60000)
+ */
+const buckets = new Map();
+
+function getLimit() {
+  return Math.max(1, parseInt(process.env.CAIRO_RATE_LIMIT || '120', 10));
+}
+
+function getWindowMs() {
+  return Math.max(1000, parseInt(process.env.CAIRO_RATE_WINDOW_MS || '60000', 10));
+}
+
+function rateLimit(req, res, next) {
+  // Skip health / docs / discovery
+  const path = req.path || '';
+  if (
+    path === '/health' ||
+    path === '/health/simple' ||
+    path === '/health/detailed' ||
+    path === '/' ||
+    path === '/llms.txt' ||
+    path === '/docs' ||
+    path.startsWith('/docs/') ||
+    path === '/.well-known/mcp.json'
+  ) {
+    return next();
+  }
+
+  const key =
+    req.writeKey ||
+    req.headers['x-write-key'] ||
+    req.headers.authorization ||
+    req.ip ||
+    'anonymous';
+
+  const now = Date.now();
+  const windowMs = getWindowMs();
+  const limit = getLimit();
+
+  let bucket = buckets.get(key);
+  if (!bucket || now - bucket.start >= windowMs) {
+    bucket = { start: now, count: 0 };
+    buckets.set(key, bucket);
+  }
+
+  bucket.count += 1;
+
+  res.setHeader('X-RateLimit-Limit', String(limit));
+  res.setHeader('X-RateLimit-Remaining', String(Math.max(0, limit - bucket.count)));
+  res.setHeader('X-RateLimit-Reset', String(Math.ceil((bucket.start + windowMs) / 1000)));
+
+  if (bucket.count > limit) {
+    const retryAfter = Math.ceil((bucket.start + windowMs - now) / 1000);
+    res.setHeader('Retry-After', String(retryAfter));
+    return res.status(429).json({
+      success: false,
+      error: 'Rate limit exceeded',
+      retryAfter,
+    });
+  }
+
+  next();
+}
+
+/** Periodic cleanup to avoid unbounded Map growth */
+setInterval(() => {
+  const now = Date.now();
+  const windowMs = getWindowMs();
+  for (const [k, bucket] of buckets.entries()) {
+    if (now - bucket.start >= windowMs * 2) buckets.delete(k);
+  }
+}, 60_000).unref?.();
+
+module.exports = { rateLimit };

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -236,33 +236,61 @@ class NotificationService {
   }
 
   async _pushToAgent(agentId, notification, namespace) {
+    const maxAttempts = Math.max(1, parseInt(process.env.CAIRO_WEBHOOK_RETRIES || '3', 10));
+    const baseDelayMs = Math.max(50, parseInt(process.env.CAIRO_WEBHOOK_RETRY_DELAY_MS || '250', 10));
+
+    let url;
     try {
       const result = await query(
         `SELECT webhook_url FROM agent_endpoints WHERE agent_id = $1 AND namespace = $2`,
         [agentId, namespace]
       );
-      const url = result.rows[0]?.webhook_url;
-      if (!url) return;
-
-      await axios.post(
-        url,
-        {
-          type: 'notification',
-          notification: {
-            id: notification.id,
-            event: notification.event_name,
-            userId: notification.user_id,
-            message: notification.message,
-            payload: notification.payload,
-            channels: notification.payload?.channels || {},
-            createdAt: notification.created_at,
-          },
-        },
-        { timeout: 8000 }
-      );
+      url = result.rows[0]?.webhook_url;
     } catch (err) {
-      logger.warn(`[notifications] agent webhook push failed for ${agentId}:`, err.message);
+      logger.warn(`[notifications] agent endpoint lookup failed:`, err.message);
+      return { pushed: false, reason: 'lookup_failed' };
     }
+
+    if (!url) return { pushed: false, reason: 'no_webhook' };
+
+    const body = {
+      type: 'notification',
+      notification: {
+        id: notification.id,
+        event: notification.event_name,
+        userId: notification.user_id,
+        message: notification.message,
+        payload: notification.payload,
+        channels: notification.payload?.channels || {},
+        createdAt: notification.created_at,
+      },
+    };
+
+    let lastError = null;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await axios.post(url, body, { timeout: 8000 });
+        return { pushed: true, attempts: attempt };
+      } catch (err) {
+        lastError = err.response?.data?.message || err.message;
+        logger.warn(
+          `[notifications] webhook push attempt ${attempt}/${maxAttempts} failed for ${agentId}: ${lastError}`
+        );
+        if (attempt < maxAttempts) {
+          await new Promise((r) => setTimeout(r, baseDelayMs * 2 ** (attempt - 1)));
+        }
+      }
+    }
+
+    // Exhausted retries — leave pending for pull, but record error
+    try {
+      await query(
+        `UPDATE notifications SET error = $1, updated_at = NOW() WHERE id = $2`,
+        [`webhook_failed_after_${maxAttempts}: ${lastError}`, notification.id]
+      );
+    } catch (_) { /* */ }
+
+    return { pushed: false, reason: 'exhausted', error: lastError, attempts: maxAttempts };
   }
 
   /**

--- a/src/routes/mcpRoutes.js
+++ b/src/routes/mcpRoutes.js
@@ -54,6 +54,7 @@ class McpRoutes {
       if (name.includes('identity') || name === 'alias_identity') return 'identity';
       if (['track_event', 'batch_track', 'query_events'].includes(name)) return 'events';
       if (['identify_user', 'lookup_user'].includes(name)) return 'users';
+      if (name.includes('write_key')) return 'auth';
       return 'system';
     };
 

--- a/src/services/mcpService.js
+++ b/src/services/mcpService.js
@@ -384,8 +384,38 @@ class McpService {
       },
     }, this._toolQueryAgentSessions);
 
-    // ── System ─────────────────────────────────────────────────────────
-    register('system_health', 'Check Cairo health and configured notification channels.', {
+    // ── System / auth ────────────────────────────────────────────────────
+    register('create_write_key', 'Create a new write key. Returns the full key once — store it securely.', {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        key: { type: 'string', description: 'Optional custom key value; auto-generated if omitted' },
+      },
+    }, async (args) => {
+      const { createWriteKey } = require('../middleware/auth');
+      return createWriteKey({ name: args.name || 'default', key: args.key });
+    });
+
+    register('list_write_keys', 'List write keys (prefixes only; full secrets are not returned).', {
+      type: 'object',
+      properties: {},
+    }, async () => {
+      const { listWriteKeys } = require('../middleware/auth');
+      return listWriteKeys();
+    });
+
+    register('revoke_write_key', 'Revoke a write key by id or full key value.', {
+      type: 'object',
+      properties: { id: { type: 'string', description: 'Write key id or full key' } },
+      required: ['id'],
+    }, async (args) => {
+      const { revokeWriteKey } = require('../middleware/auth');
+      const row = await revokeWriteKey(args.id);
+      if (!row) throw new Error('Key not found or already revoked');
+      return row;
+    });
+
+    register('system_health', 'Check Cairo health and delivery mode.', {
       type: 'object',
       properties: {},
     }, this._toolSystemHealth);
@@ -606,10 +636,20 @@ class McpService {
       dbOk = true;
     } catch (_) { /* */ }
 
+    const { requireKeysEnforced, loadWriteKeys } = require('../middleware/auth');
+    let keyCount = 0;
+    try {
+      const cache = await loadWriteKeys();
+      keyCount = cache.keys.size;
+    } catch (_) { /* */ }
+
     return {
       status: dbOk ? 'healthy' : 'degraded',
       version: this.serverInfo.version,
       delivery: 'agent-handoff',
+      write_keys_enforced: requireKeysEnforced(),
+      write_keys_active: keyCount,
+      rate_limit: parseInt(process.env.CAIRO_RATE_LIMIT || '120', 10),
       tool_count: Object.keys(this.tools).length,
       timestamp: new Date().toISOString(),
     };

--- a/src/test/auth.test.js
+++ b/src/test/auth.test.js
@@ -1,0 +1,34 @@
+describe('auth enforcement helpers', () => {
+  const prevEnv = process.env.NODE_ENV;
+  const prevRequire = process.env.CAIRO_REQUIRE_WRITE_KEYS;
+
+  afterEach(() => {
+    process.env.NODE_ENV = prevEnv;
+    if (prevRequire === undefined) delete process.env.CAIRO_REQUIRE_WRITE_KEYS;
+    else process.env.CAIRO_REQUIRE_WRITE_KEYS = prevRequire;
+  });
+
+  it('requireKeysEnforced is true in production', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.CAIRO_REQUIRE_WRITE_KEYS;
+    jest.resetModules();
+    const { requireKeysEnforced } = require('../middleware/auth');
+    expect(requireKeysEnforced()).toBe(true);
+  });
+
+  it('requireKeysEnforced is true when CAIRO_REQUIRE_WRITE_KEYS=true', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.CAIRO_REQUIRE_WRITE_KEYS = 'true';
+    jest.resetModules();
+    const { requireKeysEnforced } = require('../middleware/auth');
+    expect(requireKeysEnforced()).toBe(true);
+  });
+
+  it('generateWriteKey returns ck_ prefix', () => {
+    jest.resetModules();
+    const { generateWriteKey } = require('../middleware/auth');
+    const key = generateWriteKey();
+    expect(key.startsWith('ck_')).toBe(true);
+    expect(key.length).toBeGreaterThan(20);
+  });
+});

--- a/src/test/mcpRegistry.test.js
+++ b/src/test/mcpRegistry.test.js
@@ -24,6 +24,9 @@ describe('McpService registry', () => {
       'enqueue_notification',
       'register_agent_webhook',
       'set_user_channel',
+      'create_write_key',
+      'list_write_keys',
+      'revoke_write_key',
       'system_health',
     ]));
     // Direct gateway send must NOT exist

--- a/src/test/rateLimit.test.js
+++ b/src/test/rateLimit.test.js
@@ -1,0 +1,56 @@
+const { rateLimit } = require('../middleware/rateLimit');
+
+function mockRes() {
+  const headers = {};
+  return {
+    headers,
+    statusCode: 200,
+    body: null,
+    setHeader(k, v) { headers[k] = v; },
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.body = body; return this; },
+  };
+}
+
+describe('rateLimit middleware', () => {
+  const prevLimit = process.env.CAIRO_RATE_LIMIT;
+  const prevWindow = process.env.CAIRO_RATE_WINDOW_MS;
+
+  beforeAll(() => {
+    process.env.CAIRO_RATE_LIMIT = '3';
+    process.env.CAIRO_RATE_WINDOW_MS = '60000';
+  });
+
+  afterAll(() => {
+    if (prevLimit === undefined) delete process.env.CAIRO_RATE_LIMIT;
+    else process.env.CAIRO_RATE_LIMIT = prevLimit;
+    if (prevWindow === undefined) delete process.env.CAIRO_RATE_WINDOW_MS;
+    else process.env.CAIRO_RATE_WINDOW_MS = prevWindow;
+  });
+
+  it('allows requests under the limit and 429s after', () => {
+    const key = `test-key-${Date.now()}`;
+    let allowed = 0;
+    let blocked = 0;
+
+    for (let i = 0; i < 5; i++) {
+      const req = { path: '/v2/track', writeKey: key, headers: {}, ip: '1.2.3.4' };
+      const res = mockRes();
+      let nextCalled = false;
+      rateLimit(req, res, () => { nextCalled = true; });
+      if (nextCalled) allowed += 1;
+      else if (res.statusCode === 429) blocked += 1;
+    }
+
+    expect(allowed).toBe(3);
+    expect(blocked).toBe(2);
+  });
+
+  it('skips health endpoints', () => {
+    const req = { path: '/health', writeKey: 'x', headers: {}, ip: '9.9.9.9' };
+    const res = mockRes();
+    let nextCalled = false;
+    rateLimit(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce write keys when `NODE_ENV=production` or `CAIRO_REQUIRE_WRITE_KEYS=true` (no empty-table bootstrap)
- CLI + MCP: `create-write-key` / `list-write-keys` / `revoke-write-key`
- Agent webhook push retries with exponential backoff; errors recorded on the notification row
- Per-write-key rate limiting (default 120/min)
- Honest README + `docs/PUBLISHING.md` (packages still unpublished)

## Test plan
- [ ] `npm test` (12 tests)
- [ ] `node bin/cairo.js create-write-key --name prod` against a migrated DB
- [ ] With `CAIRO_REQUIRE_WRITE_KEYS=true` and empty `write_keys`, requests return 401
- [ ] After creating a key, `/mcp` and `/v2/track` work with that key
- [ ] Burst > rate limit returns 429 with `Retry-After`
- [ ] Register a bad agent webhook URL → retries then `error` column set; pull queue still works


Made with [Cursor](https://cursor.com)