### PR TITLE
chore: publish @ani-hq packages to npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,41 @@
+name: Publish npm packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run only (no publish)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          chmod +x scripts/publish-packages.sh
+          ./scripts/publish-packages.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ INSERT INTO write_keys (key, name) VALUES ('dev-key', 'local');
 - Primary interface: `POST /mcp`
 - Product ingest: `POST /v2/track` / `POST /v2/batch` (also under `/api/v2`)
 - Notifications hand off to agents; agents relay via their own gateways
-- Packages live under `packages/` (workspaces): `@cairo/tracker`, `@cairo/agent-tracker`, `@cairo/agent-mcp`
+- Packages live under `packages/` (workspaces): `@ani-hq/tracker`, `@ani-hq/agent-tracker`, `@ani-hq/agent-mcp`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Open-source, agent-first event tracking. Agents are the primary user. Track even
 
 Cairo does **not** connect to messaging gateways itself.
 
-> **Status:** dogfood / early production. Self-host from git. npm packages (`@cairo/*`) are not published yet.
+> **Status:** dogfood / early production. Self-host from git. Client packages publish on npm as `@ani-hq/*`.
 
 ## Why Cairo
 
@@ -43,18 +43,14 @@ curl -X POST https://your-cairo.com/mcp \
   }}'
 ```
 
-Agent self-reporting via stdio MCP (from this repo until packages are published):
-
-```bash
-cd packages/agent-mcp && npm install && npm run build
-```
+Agent self-reporting via stdio MCP:
 
 ```json
 {
   "mcpServers": {
     "cairo-agent": {
-      "command": "node",
-      "args": ["/absolute/path/to/cairo/packages/agent-mcp/dist/index.js"],
+      "command": "npx",
+      "args": ["-y", "@ani-hq/agent-mcp"],
       "env": {
         "CAIRO_HOST": "https://your-cairo-instance.com",
         "CAIRO_WRITE_KEY": "YOUR_KEY",
@@ -67,16 +63,13 @@ cd packages/agent-mcp && npm install && npm run build
 
 ### For Apps (SDK)
 
-Packages are not on npm yet. Install from git/workspace:
-
 ```bash
-# from this monorepo
-cd packages/tracker && npm install && npm run build
-npm install /absolute/path/to/cairo/packages/tracker
+npm install @ani-hq/tracker
+# or: npm install @ani-hq/agent-tracker
 ```
 
 ```typescript
-import { Cairo } from '@cairo/tracker';
+import { Cairo } from '@ani-hq/tracker';
 
 const cairo = Cairo.init({
   writeKey: 'YOUR_KEY',

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -40,7 +40,7 @@ Primary ingestion endpoint. The SDK uses this for all event delivery.
         "agent_id": "my-agent",
         "instance_id": "uuid",
         "session_id": "uuid",
-        "library": { "name": "@cairo/agent-tracker", "version": "1.0.0" }
+        "library": { "name": "@ani-hq/agent-tracker", "version": "1.0.0" }
       }
     }
   ],

--- a/docs/EVENT_TRACKING_GUIDE.md
+++ b/docs/EVENT_TRACKING_GUIDE.md
@@ -2,20 +2,20 @@
 
 ## Overview
 
-`@cairo/agent-tracker` is a TypeScript SDK for tracking AI agent behavior. It collects structured events (LLM generations, tool calls, decisions, errors, handoffs) and sends them to a Cairo server, which processes them through an event pipeline and routes them to configured destinations.
+`@ani-hq/agent-tracker` is a TypeScript SDK for tracking AI agent behavior. It collects structured events (LLM generations, tool calls, decisions, errors, handoffs) and sends them to a Cairo server, which processes them through an event pipeline and routes them to configured destinations.
 
 The SDK uses native `fetch`, queue-based batching, and automatic session accumulation. It has zero runtime dependencies beyond `uuid`.
 
 ## Installation
 
 ```bash
-npm install @cairo/agent-tracker
+npm install @ani-hq/agent-tracker
 ```
 
 ## Configuration
 
 ```typescript
-import { AgentTracker } from '@cairo/agent-tracker';
+import { AgentTracker } from '@ani-hq/agent-tracker';
 
 const tracker = AgentTracker.init({
   writeKey: 'your-write-key',
@@ -250,7 +250,7 @@ The `session.end()` call emits an `agent.session.end` event with:
 `CairoCallbackHandler` implements the LangChain callback interface. It automatically tracks generations, tool calls, and errors from any chain or agent.
 
 ```typescript
-import { CairoCallbackHandler } from '@cairo/agent-tracker/middleware/langchain';
+import { CairoCallbackHandler } from '@ani-hq/agent-tracker/middleware/langchain';
 
 const handler = new CairoCallbackHandler(tracker);
 
@@ -272,7 +272,7 @@ Tracked automatically: `handleLLMStart/End` (generations with token counts and l
 
 ```typescript
 import OpenAI from 'openai';
-import { wrapOpenAI } from '@cairo/agent-tracker/middleware/openai';
+import { wrapOpenAI } from '@ani-hq/agent-tracker/middleware/openai';
 
 const openai = wrapOpenAI(new OpenAI(), tracker);
 
@@ -291,7 +291,7 @@ Two options: manual tracking with `trackVercelAI`, or auto-tracking with `create
 
 ```typescript
 import { generateText } from 'ai';
-import { trackVercelAI, createTrackedGenerateText } from '@cairo/agent-tracker/middleware/vercel-ai';
+import { trackVercelAI, createTrackedGenerateText } from '@ani-hq/agent-tracker/middleware/vercel-ai';
 
 // Option 1: Manual
 const result = await generateText({ model, prompt });

--- a/docs/EVENT_TRACKING_QUICK_REFERENCE.md
+++ b/docs/EVENT_TRACKING_QUICK_REFERENCE.md
@@ -5,13 +5,13 @@ Track AI agent behavior in 5 minutes. Events flow through Cairo's pipeline and g
 ## Install
 
 ```bash
-npm install @cairo/agent-tracker
+npm install @ani-hq/agent-tracker
 ```
 
 ## Initialize
 
 ```typescript
-import { AgentTracker } from '@cairo/agent-tracker';
+import { AgentTracker } from '@ani-hq/agent-tracker';
 
 const tracker = AgentTracker.init({
   writeKey: 'your-write-key',
@@ -86,7 +86,7 @@ Add the Cairo MCP server so agents can self-report events over stdio.
   "mcpServers": {
     "cairo": {
       "command": "npx",
-      "args": ["-y", "@cairo/agent-mcp"],
+      "args": ["-y", "@ani-hq/agent-mcp"],
       "env": {
         "CAIRO_WRITE_KEY": "your-write-key",
         "CAIRO_HOST": "https://your-cairo-instance.com",
@@ -104,7 +104,7 @@ The MCP server exposes tools: `track_generation`, `track_tool_call`, `track_deci
 ### LangChain
 
 ```typescript
-import { CairoCallbackHandler } from '@cairo/agent-tracker/middleware/langchain';
+import { CairoCallbackHandler } from '@ani-hq/agent-tracker/middleware/langchain';
 
 const handler = new CairoCallbackHandler(tracker);
 const chain = new LLMChain({ llm, prompt, callbacks: [handler] });
@@ -113,7 +113,7 @@ const chain = new LLMChain({ llm, prompt, callbacks: [handler] });
 ### OpenAI
 
 ```typescript
-import { wrapOpenAI } from '@cairo/agent-tracker/middleware/openai';
+import { wrapOpenAI } from '@ani-hq/agent-tracker/middleware/openai';
 import OpenAI from 'openai';
 
 const openai = wrapOpenAI(new OpenAI(), tracker);
@@ -123,7 +123,7 @@ const openai = wrapOpenAI(new OpenAI(), tracker);
 ### Vercel AI SDK
 
 ```typescript
-import { createTrackedGenerateText } from '@cairo/agent-tracker/middleware/vercel-ai';
+import { createTrackedGenerateText } from '@ani-hq/agent-tracker/middleware/vercel-ai';
 import { generateText } from 'ai';
 
 const trackedGenerate = createTrackedGenerateText(tracker, generateText);

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,31 +1,34 @@
-# Publishing @cairo packages (when ready)
+# Publishing @cairo packages
 
-Packages live under `packages/` and are **not published to npm yet**.
+## One-time setup (you)
 
-## Prerequisites
+1. Create an npm org named **`cairo`**: https://www.npmjs.com/org/create  
+   (Scoped packages `@cairo/*` require this org, or a user named `cairo`.)
+2. Create an **Automation** access token: https://www.npmjs.com/settings/~/tokens  
+   - Type: Automation  
+   - Grant publish access to the `cairo` org
+3. Add the token as a GitHub Actions secret named **`NPM_TOKEN`** on `outcome-driven-studio/cairo`  
+   Or export it locally: `export NPM_TOKEN=npm_...`
 
-1. Create an npm organization named `cairo` (or change package names).
-2. `npm login` with an account that can publish public scoped packages.
-3. Each package already has `"publishConfig": { "access": "public" }`.
+Root package is **not** published as `cairo` (that name is taken on npm by an unrelated package). Server distribution = git + Docker.
 
-## Build & publish
+## Publish (local)
 
 ```bash
-# from repo root
-npm install
-npm run build
+export NPM_TOKEN=npm_...   # or: npm login
+chmod +x scripts/publish-packages.sh
+./scripts/publish-packages.sh
 
-# publish each package (version bump first)
-cd packages/tracker && npm version patch && npm publish --access public
-cd ../agent-tracker && npm version patch && npm publish --access public
-cd ../agent-mcp && npm version patch && npm publish --access public
+# dry run:
+DRY_RUN=true ./scripts/publish-packages.sh
 ```
 
-Until then, consumers should install from git/path as documented in the root README.
+## Publish (GitHub Actions)
 
-## Root server package
+Actions → **Publish npm packages** → Run workflow.
 
-Root `package.json` is named `cairo` (v3). Publishing it would conflict with the unrelated existing `cairo` package on npm (`0.1.0-alpha.3`). Prefer:
+Or create a GitHub Release; the workflow also runs on `release: published`.
 
-- Distribute the server via git + Docker, or
-- Publish as `@cairo/server` / `cairo-cdp` after renaming
+## After publish
+
+`npm install @cairo/tracker` and `npx -y @cairo/agent-mcp` should work. Update the root README if needed (remove “not published yet” notes).

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,21 +1,18 @@
-# Publishing @cairo packages
+# Publishing @ani-hq packages
 
-## One-time setup (you)
+Packages publish under the existing **`ani-hq`** npm org.
 
-1. Create an npm org named **`cairo`**: https://www.npmjs.com/org/create  
-   (Scoped packages `@cairo/*` require this org, or a user named `cairo`.)
-2. Create an **Automation** access token: https://www.npmjs.com/settings/~/tokens  
-   - Type: Automation  
-   - Grant publish access to the `cairo` org
-3. Add the token as a GitHub Actions secret named **`NPM_TOKEN`** on `outcome-driven-studio/cairo`  
-   Or export it locally: `export NPM_TOKEN=npm_...`
+## One-time setup
 
-Root package is **not** published as `cairo` (that name is taken on npm by an unrelated package). Server distribution = git + Docker.
+1. Automation token with publish access to `ani-hq`: https://www.npmjs.com/settings/~/tokens
+2. Add as GitHub secret **`NPM_TOKEN`**, or `export NPM_TOKEN=npm_...`
 
-## Publish (local)
+Root package is **private** (server ships via git + Docker).
+
+## Publish
 
 ```bash
-export NPM_TOKEN=npm_...   # or: npm login
+export NPM_TOKEN=npm_...
 chmod +x scripts/publish-packages.sh
 ./scripts/publish-packages.sh
 
@@ -23,12 +20,10 @@ chmod +x scripts/publish-packages.sh
 DRY_RUN=true ./scripts/publish-packages.sh
 ```
 
-## Publish (GitHub Actions)
+Or Actions → **Publish npm packages** → Run workflow.
 
-Actions → **Publish npm packages** → Run workflow.
+## Packages
 
-Or create a GitHub Release; the workflow also runs on `release: published`.
-
-## After publish
-
-`npm install @cairo/tracker` and `npx -y @cairo/agent-mcp` should work. Update the root README if needed (remove “not published yet” notes).
+- `@ani-hq/tracker`
+- `@ani-hq/agent-tracker`
+- `@ani-hq/agent-mcp`

--- a/docs/TECHNICAL_ARCHITECTURE.md
+++ b/docs/TECHNICAL_ARCHITECTURE.md
@@ -10,8 +10,8 @@ Cairo is a server-side event pipeline that ingests, processes, and routes events
 Sources                      Cairo Server                              Destinations
 --------------------------   ----------------------------------------  ---------------------------
                              +--------------------------------------+
-  @cairo/agent-tracker --->  |                                      |  --> Slack
-  @cairo/agent-mcp    --->  |  Ingestion     Processing    Routing |  --> Mixpanel
+  @ani-hq/agent-tracker --->  |                                      |  --> Slack
+  @ani-hq/agent-mcp    --->  |  Ingestion     Processing    Routing |  --> Mixpanel
   HTTP (curl, any SDK) --->  |  (auth,        (suppress,   (fan-out|  --> BigQuery
                              |   validate)     identity,    per     |  --> Snowflake
                              |                 transform,   dest)   |  --> Kafka
@@ -128,7 +128,7 @@ Key database tables:
 
 ## SDKs
 
-### @cairo/agent-tracker
+### @ani-hq/agent-tracker
 
 TypeScript SDK. Uses native `fetch` (no HTTP library dependency). Queue-based batching with configurable `flushAt` and `flushInterval`. Session objects auto-accumulate token counts, costs, tool calls, and errors. Sampling, input redaction, and property truncation are built in.
 
@@ -137,9 +137,9 @@ Framework middleware:
 - **OpenAI**: `wrapOpenAI` patches `chat.completions.create`
 - **Vercel AI SDK**: `trackVercelAI` and `createTrackedGenerateText`
 
-### @cairo/agent-mcp
+### @ani-hq/agent-mcp
 
-MCP server for Claude, GPT, and other MCP-capable agents. Runs over stdio transport. Contains a self-contained event poster (does not depend on `@cairo/agent-tracker`). Exposes 6 MCP tools: `track_generation`, `track_tool_call`, `track_decision`, `track_error`, `start_session`, `end_session`.
+MCP server for Claude, GPT, and other MCP-capable agents. Runs over stdio transport. Contains a self-contained event poster (does not depend on `@ani-hq/agent-tracker`). Exposes 6 MCP tools: `track_generation`, `track_tool_call`, `track_decision`, `track_error`, `start_session`, `end_session`.
 
 Configuration via environment variables: `CAIRO_WRITE_KEY`, `CAIRO_HOST`, `CAIRO_AGENT_ID`, `CAIRO_DEBUG`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,15 +589,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@cairo/agent-mcp": {
+    "node_modules/@ani-hq/agent-mcp": {
       "resolved": "packages/agent-mcp",
       "link": true
     },
-    "node_modules/@cairo/agent-tracker": {
+    "node_modules/@ani-hq/agent-tracker": {
       "resolved": "packages/agent-tracker",
       "link": true
     },
-    "node_modules/@cairo/tracker": {
+    "node_modules/@ani-hq/tracker": {
       "resolved": "packages/tracker",
       "link": true
     },
@@ -6565,7 +6565,7 @@
       }
     },
     "packages/agent-mcp": {
-      "name": "@cairo/agent-mcp",
+      "name": "@ani-hq/agent-mcp",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -6599,7 +6599,7 @@
       "license": "MIT"
     },
     "packages/agent-tracker": {
-      "name": "@cairo/agent-tracker",
+      "name": "@ani-hq/agent-tracker",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -6629,7 +6629,7 @@
       "license": "MIT"
     },
     "packages/tracker": {
-      "name": "@cairo/tracker",
+      "name": "@ani-hq/tracker",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "cairo",
   "version": "3.0.0",
+  "private": true,
   "description": "Agent-first event tracking — ingest events, hand notifications to agents who relay via their own gateways",
-  "private": false,
   "bin": {
     "cairo": "./bin/cairo.js"
   },
@@ -60,7 +60,9 @@
     "setup": "node src/migrations/run_migrations.js",
     "setup-env": "node setup-env.js",
     "build": "npm run build --workspaces --if-present",
-    "migrate": "node src/migrations/run_migrations.js"
+    "migrate": "node src/migrations/run_migrations.js",
+    "publish:packages": "bash scripts/publish-packages.sh",
+    "publish:packages:dry": "DRY_RUN=true bash scripts/publish-packages.sh"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,9 +2,9 @@
 
 | Package | Purpose |
 |---------|---------|
-| `@cairo/tracker` | Universal Segment-style tracker for apps |
-| `@cairo/agent-tracker` | Agent session / generation / tool-call SDK |
-| `@cairo/agent-mcp` | stdio MCP server for agent self-reporting |
+| `@ani-hq/tracker` | Universal Segment-style tracker for apps |
+| `@ani-hq/agent-tracker` | Agent session / generation / tool-call SDK |
+| `@ani-hq/agent-mcp` | stdio MCP server for agent self-reporting |
 
 All packages post to `${host}/v2/batch` (also available as `/api/v2/batch`).
 
@@ -23,4 +23,4 @@ Install from path:
 npm install /path/to/cairo/packages/tracker
 ```
 
-For the server's full MCP tool surface (events, notifications, GDPR, write keys), connect to `POST /mcp` on a running Cairo instance — that is separate from `@cairo/agent-mcp`.
+For the server's full MCP tool surface (events, notifications, GDPR, write keys), connect to `POST /mcp` on a running Cairo instance — that is separate from `@ani-hq/agent-mcp`.

--- a/packages/agent-mcp/README.md
+++ b/packages/agent-mcp/README.md
@@ -1,9 +1,9 @@
-# @cairo/agent-mcp
+# @ani-hq/agent-mcp
 
 stdio [MCP](https://modelcontextprotocol.io) server for agent self-reporting into [Cairo](https://github.com/outcome-driven-studio/cairo).
 
 ```bash
-npx -y @cairo/agent-mcp
+npx -y @ani-hq/agent-mcp
 ```
 
 Cursor / Claude Code config:
@@ -13,7 +13,7 @@ Cursor / Claude Code config:
   "mcpServers": {
     "cairo-agent": {
       "command": "npx",
-      "args": ["-y", "@cairo/agent-mcp"],
+      "args": ["-y", "@ani-hq/agent-mcp"],
       "env": {
         "CAIRO_HOST": "https://your-cairo-instance.com",
         "CAIRO_WRITE_KEY": "your-write-key",

--- a/packages/agent-mcp/README.md
+++ b/packages/agent-mcp/README.md
@@ -1,0 +1,27 @@
+# @cairo/agent-mcp
+
+stdio [MCP](https://modelcontextprotocol.io) server for agent self-reporting into [Cairo](https://github.com/outcome-driven-studio/cairo).
+
+```bash
+npx -y @cairo/agent-mcp
+```
+
+Cursor / Claude Code config:
+
+```json
+{
+  "mcpServers": {
+    "cairo-agent": {
+      "command": "npx",
+      "args": ["-y", "@cairo/agent-mcp"],
+      "env": {
+        "CAIRO_HOST": "https://your-cairo-instance.com",
+        "CAIRO_WRITE_KEY": "your-write-key",
+        "CAIRO_AGENT_ID": "my-agent"
+      }
+    }
+  }
+}
+```
+
+This package is for **agent self-telemetry**. The full Cairo tool surface (events, notification handoff, GDPR, etc.) is on the server at `POST /mcp`.

--- a/packages/agent-mcp/package-lock.json
+++ b/packages/agent-mcp/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cairo/agent-mcp",
+  "name": "@ani-hq/agent-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cairo/agent-mcp",
+      "name": "@ani-hq/agent-mcp",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/agent-mcp/package.json
+++ b/packages/agent-mcp/package.json
@@ -7,7 +7,14 @@
   "bin": {
     "cairo-agent-mcp": "./dist/index.js"
   },
-  "files": ["dist"],
+  "files": ["dist", "README.md"],
+  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/agent-mcp",
+  "bugs": {
+    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/agent-mcp/package.json
+++ b/packages/agent-mcp/package.json
@@ -1,13 +1,16 @@
 {
-  "name": "@cairo/agent-mcp",
-  "version": "1.0.0",
+  "name": "@ani-hq/agent-mcp",
+  "version": "1.0.1",
   "description": "stdio MCP server for AI agent self-reporting into Cairo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
     "cairo-agent-mcp": "./dist/index.js"
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/agent-mcp",
   "bugs": {
     "url": "https://github.com/outcome-driven-studio/cairo/issues"
@@ -25,7 +28,11 @@
     "prepublishOnly": "npm run build"
   },
   "keywords": [
-    "cairo", "mcp", "agent", "tracking", "model-context-protocol"
+    "cairo",
+    "mcp",
+    "agent",
+    "tracking",
+    "model-context-protocol"
   ],
   "author": "Cairo Team",
   "license": "MIT",

--- a/packages/agent-mcp/src/index.ts
+++ b/packages/agent-mcp/src/index.ts
@@ -60,7 +60,7 @@ class EventPoster {
         agent_id: this.agentId,
         instance_id: this.instanceId,
         session_id: this.sessionId,
-        library: { name: '@cairo/agent-mcp', version: '1.0.0' },
+        library: { name: '@ani-hq/agent-mcp', version: '1.0.0' },
       },
     });
 

--- a/packages/agent-tracker/README.md
+++ b/packages/agent-tracker/README.md
@@ -1,0 +1,23 @@
+# @cairo/agent-tracker
+
+Track AI agent sessions, LLM generations, tool calls, decisions, and errors into [Cairo](https://github.com/outcome-driven-studio/cairo).
+
+```bash
+npm install @cairo/agent-tracker
+```
+
+```ts
+import { AgentTracker } from '@cairo/agent-tracker';
+
+const tracker = AgentTracker.init({
+  writeKey: process.env.CAIRO_WRITE_KEY!,
+  host: 'https://your-cairo-instance.com',
+  agentId: 'my-agent',
+});
+
+const session = tracker.startSession({ task: 'answer question' });
+tracker.trackGeneration({ model: 'gpt-4o', inputTokens: 10, outputTokens: 20 });
+await tracker.endSession();
+```
+
+Posts to `${host}/v2/batch`.

--- a/packages/agent-tracker/README.md
+++ b/packages/agent-tracker/README.md
@@ -1,13 +1,13 @@
-# @cairo/agent-tracker
+# @ani-hq/agent-tracker
 
 Track AI agent sessions, LLM generations, tool calls, decisions, and errors into [Cairo](https://github.com/outcome-driven-studio/cairo).
 
 ```bash
-npm install @cairo/agent-tracker
+npm install @ani-hq/agent-tracker
 ```
 
 ```ts
-import { AgentTracker } from '@cairo/agent-tracker';
+import { AgentTracker } from '@ani-hq/agent-tracker';
 
 const tracker = AgentTracker.init({
   writeKey: process.env.CAIRO_WRITE_KEY!,

--- a/packages/agent-tracker/package-lock.json
+++ b/packages/agent-tracker/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cairo/agent-tracker",
+  "name": "@ani-hq/agent-tracker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cairo/agent-tracker",
+      "name": "@ani-hq/agent-tracker",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/agent-tracker/package.json
+++ b/packages/agent-tracker/package.json
@@ -4,7 +4,14 @@
   "description": "Agent behavior tracking SDK for Cairo — generations, tool calls, decisions, errors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": ["dist", "README.md"],
+  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/agent-tracker",
+  "bugs": {
+    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/agent-tracker/package.json
+++ b/packages/agent-tracker/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "@cairo/agent-tracker",
-  "version": "1.0.0",
+  "name": "@ani-hq/agent-tracker",
+  "version": "1.0.1",
   "description": "Agent behavior tracking SDK for Cairo — generations, tool calls, decisions, errors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/agent-tracker",
   "bugs": {
     "url": "https://github.com/outcome-driven-studio/cairo/issues"
@@ -21,7 +24,12 @@
     "prepublishOnly": "npm run build"
   },
   "keywords": [
-    "cairo", "agent", "tracking", "llm", "observability", "mcp"
+    "cairo",
+    "agent",
+    "tracking",
+    "llm",
+    "observability",
+    "mcp"
   ],
   "author": "Cairo Team",
   "license": "MIT",

--- a/packages/agent-tracker/src/index.ts
+++ b/packages/agent-tracker/src/index.ts
@@ -17,7 +17,7 @@ import {
   TrackMessage,
 } from './types';
 
-const LIBRARY_NAME = '@cairo/agent-tracker';
+const LIBRARY_NAME = '@ani-hq/agent-tracker';
 const LIBRARY_VERSION = '1.0.0';
 
 const DEFAULT_CONFIG: Partial<AgentTrackerConfig> = {

--- a/packages/agent-tracker/src/middleware/langchain.ts
+++ b/packages/agent-tracker/src/middleware/langchain.ts
@@ -5,7 +5,7 @@ import { AgentTracker } from '../index';
  * Automatically tracks LLM generations, tool calls, and errors from LangChain chains/agents.
  *
  * Usage:
- *   import { CairoCallbackHandler } from '@cairo/agent-tracker/middleware/langchain';
+ *   import { CairoCallbackHandler } from '@ani-hq/agent-tracker/middleware/langchain';
  *   const handler = new CairoCallbackHandler(tracker);
  *   const chain = new LLMChain({ llm, prompt, callbacks: [handler] });
  */

--- a/packages/agent-tracker/src/middleware/openai.ts
+++ b/packages/agent-tracker/src/middleware/openai.ts
@@ -4,7 +4,7 @@ import { AgentTracker } from '../index';
  * OpenAI client wrapper that automatically tracks generations.
  *
  * Usage:
- *   import { wrapOpenAI } from '@cairo/agent-tracker/middleware/openai';
+ *   import { wrapOpenAI } from '@ani-hq/agent-tracker/middleware/openai';
  *   const openai = wrapOpenAI(new OpenAI(), tracker);
  *   // All chat.completions.create calls are now tracked
  */

--- a/packages/agent-tracker/src/middleware/vercel-ai.ts
+++ b/packages/agent-tracker/src/middleware/vercel-ai.ts
@@ -5,7 +5,7 @@ import { AgentTracker } from '../index';
  * Wraps the `generateText` / `streamText` result to track generations.
  *
  * Usage:
- *   import { trackVercelAI } from '@cairo/agent-tracker/middleware/vercel-ai';
+ *   import { trackVercelAI } from '@ani-hq/agent-tracker/middleware/vercel-ai';
  *   const result = await generateText({ model, prompt });
  *   trackVercelAI(tracker, result);
  */

--- a/packages/tracker/README.md
+++ b/packages/tracker/README.md
@@ -1,13 +1,13 @@
-# @cairo/tracker
+# @ani-hq/tracker
 
 Universal Segment-style event tracking SDK for [Cairo](https://github.com/outcome-driven-studio/cairo).
 
 ```bash
-npm install @cairo/tracker
+npm install @ani-hq/tracker
 ```
 
 ```ts
-import { Cairo } from '@cairo/tracker';
+import { Cairo } from '@ani-hq/tracker';
 
 const cairo = Cairo.init({
   writeKey: process.env.CAIRO_WRITE_KEY!,

--- a/packages/tracker/README.md
+++ b/packages/tracker/README.md
@@ -1,0 +1,22 @@
+# @cairo/tracker
+
+Universal Segment-style event tracking SDK for [Cairo](https://github.com/outcome-driven-studio/cairo).
+
+```bash
+npm install @cairo/tracker
+```
+
+```ts
+import { Cairo } from '@cairo/tracker';
+
+const cairo = Cairo.init({
+  writeKey: process.env.CAIRO_WRITE_KEY!,
+  host: 'https://your-cairo-instance.com',
+});
+
+cairo.track({ event: 'signup', userId: 'u1', properties: { plan: 'free' } });
+cairo.identify({ userId: 'u1', traits: { email: 'a@b.com' } });
+await cairo.shutdown();
+```
+
+Posts to `${host}/v2/batch`.

--- a/packages/tracker/package-lock.json
+++ b/packages/tracker/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cairo/tracker",
+  "name": "@ani-hq/tracker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cairo/tracker",
+      "name": "@ani-hq/tracker",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/tracker/package.json
+++ b/packages/tracker/package.json
@@ -4,7 +4,14 @@
   "description": "Universal event tracking SDK for Cairo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": ["dist", "README.md"],
+  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/tracker",
+  "bugs": {
+    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tracker/package.json
+++ b/packages/tracker/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "@cairo/tracker",
-  "version": "1.0.0",
+  "name": "@ani-hq/tracker",
+  "version": "1.0.1",
   "description": "Universal event tracking SDK for Cairo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/tracker",
   "bugs": {
     "url": "https://github.com/outcome-driven-studio/cairo/issues"
@@ -21,7 +24,12 @@
     "prepublishOnly": "npm run build"
   },
   "keywords": [
-    "cairo", "analytics", "tracking", "events", "ai-agent", "telemetry"
+    "cairo",
+    "analytics",
+    "tracking",
+    "events",
+    "ai-agent",
+    "telemetry"
   ],
   "author": "Cairo Team",
   "license": "MIT",

--- a/packages/tracker/src/index.ts
+++ b/packages/tracker/src/index.ts
@@ -11,7 +11,7 @@ import {
   Message,
 } from './types';
 
-const LIBRARY_NAME = '@cairo/tracker';
+const LIBRARY_NAME = '@ani-hq/tracker';
 const LIBRARY_VERSION = '1.0.0';
 
 const DEFAULTS: Required<Omit<TrackerConfig, 'writeKey'>> = {

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Publish @cairo/* packages to npm.
-# Requires: valid npm auth (npm login or NPM_TOKEN), and ownership of the @cairo scope.
+# Publish @ani-hq/* packages to npm.
+# Requires: valid npm auth (npm login or NPM_TOKEN), and ownership of the @ani-hq scope.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -16,7 +16,7 @@ echo "==> Checking npm auth"
 if ! npm whoami >/dev/null 2>&1; then
   echo "ERROR: not logged in to npm."
   echo "  Run: npm login"
-  echo "  Or set NPM_TOKEN to an automation token with publish rights on @cairo"
+  echo "  Or set NPM_TOKEN to an automation token with publish rights on @ani-hq"
   exit 1
 fi
 echo "Logged in as: $(npm whoami)"
@@ -44,6 +44,6 @@ for pkg in "${PACKAGES[@]}"; do
 done
 
 echo "==> Done"
-npm view @cairo/tracker version || true
-npm view @cairo/agent-tracker version || true
-npm view @cairo/agent-mcp version || true
+npm view @ani-hq/tracker version || true
+npm view @ani-hq/agent-tracker version || true
+npm view @ani-hq/agent-mcp version || true

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Publish @cairo/* packages to npm.
+# Requires: valid npm auth (npm login or NPM_TOKEN), and ownership of the @cairo scope.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DRY_RUN="${DRY_RUN:-false}"
+PACKAGES=(tracker agent-tracker agent-mcp)
+
+if [[ -n "${NPM_TOKEN:-}" ]]; then
+  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${HOME}/.npmrc-cairo-publish"
+  export NPM_CONFIG_USERCONFIG="${HOME}/.npmrc-cairo-publish"
+fi
+
+echo "==> Checking npm auth"
+if ! npm whoami >/dev/null 2>&1; then
+  echo "ERROR: not logged in to npm."
+  echo "  Run: npm login"
+  echo "  Or set NPM_TOKEN to an automation token with publish rights on @cairo"
+  exit 1
+fi
+echo "Logged in as: $(npm whoami)"
+
+echo "==> Building workspaces"
+cd "$ROOT"
+npm run build
+
+for pkg in "${PACKAGES[@]}"; do
+  dir="$ROOT/packages/$pkg"
+  name="$(node -p "require('$dir/package.json').name")"
+  version="$(node -p "require('$dir/package.json').version")"
+  echo "==> Publishing $name@$version"
+  cd "$dir"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    npm publish --access public --dry-run
+  else
+    # idempotent: skip if already published
+    if npm view "${name}@${version}" version >/dev/null 2>&1; then
+      echo "    already published, skipping"
+    else
+      npm publish --access public
+    fi
+  fi
+done
+
+echo "==> Done"
+npm view @cairo/tracker version || true
+npm view @cairo/agent-tracker version || true
+npm view @cairo/agent-mcp version || true

--- a/src/routes/docsRoutes.js
+++ b/src/routes/docsRoutes.js
@@ -259,9 +259,9 @@ ${toolSections}
 <table>
   <thead><tr><th>Package</th><th>Use for</th></tr></thead>
   <tbody>
-    <tr><td><code>@cairo/tracker</code></td><td>Universal event tracking from apps</td></tr>
-    <tr><td><code>@cairo/agent-tracker</code></td><td>AI agent session tracking (generations, tool calls, costs)</td></tr>
-    <tr><td><code>@cairo/agent-mcp</code></td><td>stdio MCP server for agent self-reporting (not the full HTTP /mcp surface)</td></tr>
+    <tr><td><code>@ani-hq/tracker</code></td><td>Universal event tracking from apps</td></tr>
+    <tr><td><code>@ani-hq/agent-tracker</code></td><td>AI agent session tracking (generations, tool calls, costs)</td></tr>
+    <tr><td><code>@ani-hq/agent-mcp</code></td><td>stdio MCP server for agent self-reporting (not the full HTTP /mcp surface)</td></tr>
   </tbody>
 </table>
 
@@ -270,7 +270,7 @@ ${toolSections}
   "mcpServers": {
     "cairo": {
       "command": "npx",
-      "args": ["-y", "@cairo/agent-mcp"],
+      "args": ["-y", "@ani-hq/agent-mcp"],
       "env": {
         "CAIRO_HOST": "${baseUrl}",
         "CAIRO_WRITE_KEY": "your-write-key",


### PR DESCRIPTION
## Summary
- Publish client packages under the existing **`ani-hq`** npm org (`@cairo` is unavailable)
- Packages live on npm as `@ani-hq/tracker`, `@ani-hq/agent-tracker`, `@ani-hq/agent-mcp` at **1.0.1**
- Docs/README updated for `npm install` / `npx -y @ani-hq/agent-mcp`
- Keep the GitHub Actions publish workflow for future releases

## Test plan
- [x] `npm install @ani-hq/tracker@1.0.1` (and siblings) succeeds
- [ ] Confirm GitHub `NPM_TOKEN` secret can publish future versions
- [ ] Rotate any npm token that was pasted in chat