### PR TITLE
feat(mcp): turnkey agent onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,56 +4,55 @@ Open-source, agent-first event tracking. Agents are the primary user. Track even
 
 Cairo does **not** connect to messaging gateways itself.
 
-> **Status:** dogfood / early production. Self-host from git. Client packages publish on npm as `@ani-hq/*`.
+> **Status:** dogfood / early production. Self-host from git. Client packages: `@ani-hq/tracker`, `@ani-hq/agent-tracker`, `@ani-hq/agent-mcp`, `@ani-hq/cairo-mcp`.
 
 ## Why Cairo
 
-- **MCP-first.** Agents connect via Model Context Protocol. Tools for events, identity, errors, notification handoff, and GDPR.
-- **Product events still work.** Frontend, backend, and mobile SDKs send to the same ingest API (`/v2/track`, `/v2/batch`).
-- **Agent handoff.** Rules enqueue notifications for agents (pull via MCP or push via webhook). Agents relay through whatever gateway they already use.
-- **Self-hosted.** Node.js + PostgreSQL. Your data stays on your infrastructure.
+- **MCP-first.** Point any agent at Cairo; say “set this up for my product and ping me on signup.”
+- **Product events still work.** Frontend, backend, and mobile SDKs send to `/v2/track`.
+- **Agent handoff.** Rules enqueue for your `agent_id`. You pull (`drain_notifications`) or get a webhook, then relay on your gateway.
+- **Self-hosted.** Node.js + PostgreSQL.
 
-## Quick Start (self-host)
+## Turnkey (agent path)
 
 ```bash
 git clone https://github.com/outcome-driven-studio/cairo.git
 cd cairo
-cp .env.example .env.local
-# set POSTGRES_URL in .env.local
+cp .env.example .env.local   # set POSTGRES_URL
+npm install && npm run migrate && npm start
 
-npm install
-npm run migrate
-node bin/cairo.js create-write-key --name local   # prints a key — save it
-npm start
+# mint an ops write key + print MCP JSON
+node bin/cairo.js agent-config --host https://your-cairo-instance.com --agent-id my-agent
 ```
 
-Production tip: set `NODE_ENV=production` (or `CAIRO_REQUIRE_WRITE_KEYS=true`) so bootstrap mode is disabled and only real keys work.
+Paste the JSON into Cursor / Claude Code / OpenClaw / Hermes (`@ani-hq/cairo-mcp`).
 
-### For Agents (MCP)
+Then tell your agent:
 
-HTTP MCP against a running Cairo instance:
+> Set up tracking for Product X. Notify me on signup, checkout_completed, and errors.
 
-```bash
-curl -X POST https://your-cairo.com/mcp \
-  -H "Content-Type: application/json" \
-  -H "X-Write-Key: YOUR_KEY" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
-    "name":"track_event",
-    "arguments":{"event":"signup","user_id":"user_123","properties":{"plan":"free"}}
-  }}'
-```
+The agent calls **`setup_product`**, returns a product write key + install snippets. Later it **`drain_notifications`** and relays in Discord/Slack/etc.
 
-Agent self-reporting via stdio MCP:
+Full ritual: [docs/AGENT_ONBOARDING.md](./docs/AGENT_ONBOARDING.md) · skill: [skills/cairo-onboarding/SKILL.md](./skills/cairo-onboarding/SKILL.md)
+
+Production tip: set `NODE_ENV=production` (or `CAIRO_REQUIRE_WRITE_KEYS=true`) so bootstrap mode is disabled.
+
+### Agent MCP packages
+
+| Package | Use |
+|---------|-----|
+| `@ani-hq/cairo-mcp` | **Full surface** — setup, rules, drain, GDPR, events |
+| `@ani-hq/agent-mcp` | Agent self-telemetry only (generations, tool calls) |
 
 ```json
 {
   "mcpServers": {
-    "cairo-agent": {
+    "cairo": {
       "command": "npx",
-      "args": ["-y", "@ani-hq/agent-mcp"],
+      "args": ["-y", "@ani-hq/cairo-mcp"],
       "env": {
         "CAIRO_HOST": "https://your-cairo-instance.com",
-        "CAIRO_WRITE_KEY": "YOUR_KEY",
+        "CAIRO_WRITE_KEY": "YOUR_OPS_KEY",
         "CAIRO_AGENT_ID": "my-agent"
       }
     }
@@ -65,14 +64,13 @@ Agent self-reporting via stdio MCP:
 
 ```bash
 npm install @ani-hq/tracker
-# or: npm install @ani-hq/agent-tracker
 ```
 
 ```typescript
 import { Cairo } from '@ani-hq/tracker';
 
 const cairo = Cairo.init({
-  writeKey: 'YOUR_KEY',
+  writeKey: 'YOUR_PRODUCT_KEY',
   host: 'https://your-cairo-instance.com',
 });
 
@@ -80,14 +78,6 @@ cairo.track({
   event: 'signup',
   userId: 'user_123',
   properties: { plan: 'free', source: 'landing_page' },
-});
-
-cairo.identify({
-  userId: 'user_123',
-  traits: {
-    email: 'ava@school.edu',
-    telegram_chat_id: '123456789', // for agents to look up when relaying
-  },
 });
 
 await cairo.shutdown();
@@ -102,33 +92,18 @@ product/agent  →  track event  →  Cairo stores event
                                       ↓
                          enqueue for agent_id
                                       ↓
-              agent pulls (MCP) or receives webhook push
+              agent drains (MCP) or receives webhook push
                                       ↓
          agent relays via its Telegram/Discord/Slack gateway
 ```
 
-Example rule (MCP `create_notification_rule`):
-
-```json
-{
-  "name": "signup-relay",
-  "event_name": "signup",
-  "agent_id": "notify-bot",
-  "message_template": "New signup: {{userId}} plan={{properties.plan}}"
-}
-```
-
-Agent loop:
-
-1. `get_pending_notifications` (or webhook push)
-2. Read `payload.channels` for gateway addresses
-3. Send via the agent's own Telegram/Discord/Slack connection
-4. `ack_notification`
+Prefer **`setup_product`** for onboarding and **`drain_notifications`** for the relay loop. Lower-level tools: `create_notification_rule`, `get_pending_notifications`, `ack_notification`.
 
 ## MCP Tools
 
 | Category | Tools |
 |----------|-------|
+| **Onboarding** | `setup_product`, `drain_notifications` |
 | **Events** | `track_event`, `batch_track`, `query_events` |
 | **Users** | `identify_user`, `lookup_user` |
 | **Identity** | `resolve_identity`, `alias_identity` |
@@ -158,6 +133,7 @@ All require `X-Write-Key` (or `Authorization: Bearer`).
 ## Ops
 
 ```bash
+node bin/cairo.js agent-config --host https://... --agent-id my-agent
 node bin/cairo.js create-write-key --name prod
 node bin/cairo.js list-write-keys
 node bin/cairo.js revoke-write-key --id <id>

--- a/bin/cairo.js
+++ b/bin/cairo.js
@@ -14,6 +14,8 @@ for (let i = 0; i < args.length; i++) {
   else if (args[i] === '--name' || args[i] === '-n') flags.name = args[++i];
   else if (args[i] === '--key') flags.key = args[++i];
   else if (args[i] === '--id') flags.id = args[++i];
+  else if (args[i] === '--host') flags.host = args[++i];
+  else if (args[i] === '--agent-id') flags.agentId = args[++i];
 }
 
 if (flags.version) {
@@ -31,6 +33,7 @@ Usage:
   cairo create-write-key [--name <name>] [--key <value>]
   cairo list-write-keys
   cairo revoke-write-key --id <id-or-key>
+  cairo agent-config [--host <url>] [--agent-id <id>] [--name <key-name>] [--key <value>]
 
 Options:
   --port, -p <port>   Port to listen on (default: 8080)
@@ -44,10 +47,12 @@ Environment:
   CAIRO_RATE_LIMIT          Requests per window (default 120)
   CAIRO_RATE_WINDOW_MS      Window size ms (default 60000)
   CAIRO_WEBHOOK_RETRIES     Agent webhook push retries (default 3)
+  BASE_URL / CAIRO_PUBLIC_URL  Public host used in agent-config output
 
 Examples:
   POSTGRES_URL=postgres://... npx cairo migrate
   POSTGRES_URL=postgres://... npx cairo create-write-key --name prod
+  POSTGRES_URL=postgres://... npx cairo agent-config --host https://cairo.example --agent-id my-agent
   POSTGRES_URL=postgres://... npx cairo --port 8080
 `);
   process.exit(0);
@@ -105,6 +110,42 @@ if (command === 'migrate') {
       process.exit(1);
     }
     console.log(`Revoked: ${row.id} (${row.name || 'unnamed'})`);
+  }).then(() => process.exit(0)).catch((e) => { console.error(e.message); process.exit(1); });
+} else if (command === 'agent-config') {
+  withDb(async () => {
+    const { createWriteKey } = require('../src/middleware/auth');
+    const host = (flags.host || process.env.BASE_URL || process.env.CAIRO_PUBLIC_URL || 'https://your-cairo-instance.com')
+      .replace(/\/$/, '');
+    const agentId = flags.agentId || 'my-agent';
+    const keyName = flags.name || `agent-${agentId}`;
+    const row = await createWriteKey({ name: keyName, key: flags.key });
+
+    const config = {
+      mcpServers: {
+        cairo: {
+          command: 'npx',
+          args: ['-y', '@ani-hq/cairo-mcp'],
+          env: {
+            CAIRO_HOST: host,
+            CAIRO_WRITE_KEY: row.key,
+            CAIRO_AGENT_ID: agentId,
+          },
+        },
+      },
+    };
+
+    console.log('Agent write key created (store securely — shown once):');
+    console.log(`  id:   ${row.id}`);
+    console.log(`  name: ${row.name}`);
+    console.log(`  key:  ${row.key}`);
+    console.log('');
+    console.log('Paste this into Cursor / Claude Code / OpenClaw MCP settings:');
+    console.log('');
+    console.log(JSON.stringify(config, null, 2));
+    console.log('');
+    console.log('Then tell your agent:');
+    console.log('  "Set up tracking for <product>; notify me on signup, checkout, and errors."');
+    console.log('It will call setup_product, then drain_notifications to relay via its gateway.');
   }).then(() => process.exit(0)).catch((e) => { console.error(e.message); process.exit(1); });
 } else if (command) {
   console.error(`Unknown command: ${command}. Try --help`);

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -1,0 +1,84 @@
+# Agent onboarding (turnkey)
+
+Cairo is agent-first: **you talk to your agent**, the agent talks to Cairo, and the agent relays alerts through its own gateway (Discord, Slack, Telegram, etc.). Cairo never opens those gateways.
+
+## 1. Connect your agent (once)
+
+On the Cairo host:
+
+```bash
+POSTGRES_URL=... node bin/cairo.js agent-config \
+  --host https://your-cairo-instance.com \
+  --agent-id my-agent
+```
+
+Paste the printed MCP JSON into Cursor, Claude Code, OpenClaw, or Hermes.
+
+Or manually:
+
+```json
+{
+  "mcpServers": {
+    "cairo": {
+      "command": "npx",
+      "args": ["-y", "@ani-hq/cairo-mcp"],
+      "env": {
+        "CAIRO_HOST": "https://your-cairo-instance.com",
+        "CAIRO_WRITE_KEY": "ck_...",
+        "CAIRO_AGENT_ID": "my-agent"
+      }
+    }
+  }
+}
+```
+
+`@ani-hq/cairo-mcp` is the **full** MCP surface (setup, rules, pending drain).  
+`@ani-hq/agent-mcp` is only for agent self-telemetry.
+
+## 2. Ask the agent to set up a product
+
+Say something like:
+
+> Set up tracking for Product X. Notify me on signup, checkout_completed, and when errors are captured.
+
+The agent should call **`setup_product`** once with:
+
+- `product_name`
+- `agent_id` (itself)
+- `events`: the event names you care about
+
+It gets back a **product write key** (shown once) plus install snippets. Give the product that key and host.
+
+## 3. Product emits events
+
+```bash
+npm install @ani-hq/tracker
+```
+
+```ts
+import { Cairo } from '@ani-hq/tracker';
+const cairo = Cairo.init({ writeKey: 'ck_product...', host: 'https://your-cairo-instance.com' });
+cairo.track({ event: 'signup', userId: 'u1', properties: { plan: 'free' } });
+```
+
+Or HTTP: `POST /v2/track` with `X-Write-Key`.
+
+## 4. Agent relays notifications
+
+On a schedule or when asked:
+
+1. **`drain_notifications`** `{ agent_id }` (optional `namespace`)
+2. Post each `message` via the agent’s gateway
+3. **`ack_notification`** `{ id }` for each delivered row
+
+Optional: **`register_agent_webhook`** for push instead of pull.
+
+## Ritual cheat sheet
+
+| Step | Tool |
+|---|---|
+| Onboard product | `setup_product` |
+| Pull alerts | `drain_notifications` |
+| Confirm delivery | `ack_notification` |
+| Add more rules later | `create_notification_rule` |
+| New ops key | `create_write_key` or `cairo agent-config` |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -27,3 +27,4 @@ Or Actions → **Publish npm packages** → Run workflow.
 - `@ani-hq/tracker`
 - `@ani-hq/agent-tracker`
 - `@ani-hq/agent-mcp`
+- `@ani-hq/cairo-mcp`

--- a/llms.txt
+++ b/llms.txt
@@ -7,6 +7,16 @@ Cairo does NOT talk to messaging gateways itself.
 Base URL: your Cairo host
 Auth: X-Write-Key header (or Authorization: Bearer <key>)
 
+## Turnkey agent path
+1. Human runs: `cairo agent-config --host <url> --agent-id <id>` → paste MCP JSON into the agent
+2. Agent MCP package: `npx -y @ani-hq/cairo-mcp` (full surface). Not `@ani-hq/agent-mcp` (telemetry only).
+3. User says: set up Product X; notify on signup / checkout / errors
+4. Agent calls `setup_product` → returns product write_key + install snippets
+5. Product posts to `/v2/track` with that key
+6. Agent calls `drain_notifications` → relays via its gateway → `ack_notification`
+
+Docs: GET /docs · GET /llms.txt · docs/AGENT_ONBOARDING.md
+
 ## Discovery
 - GET /mcp — MCP tool discovery
 - GET /docs — HTML docs
@@ -17,6 +27,12 @@ Auth: X-Write-Key header (or Authorization: Bearer <key>)
 ## MCP (POST /mcp)
 
 JSON-RPC 2.0. Methods: initialize, tools/list, tools/call, ping.
+
+### Onboarding
+- setup_product { product_name, agent_id, events[], namespace?, message_template? }
+  Creates a product write key + one rule per event. Returns write_key (once) and install snippets.
+- drain_notifications { agent_id?, namespace?, limit? }
+  Pending notifications in relay-ready shape: id, message, event, user, properties, channels.
 
 ### Events
 - track_event { event, user_id?, user_email?, anonymous_id?, properties?, namespace? }
@@ -79,9 +95,10 @@ JSON-RPC 2.0. Methods: initialize, tools/list, tools/call, ping.
 - Pass X-Write-Key or Authorization: Bearer on every /mcp and /v2 request
 - NODE_ENV=production or CAIRO_REQUIRE_WRITE_KEYS=true disables bootstrap
 - Create keys: CLI `cairo create-write-key --name prod` or MCP create_write_key
+- Agent install: `cairo agent-config --host <url> --agent-id <id>`
 
 ## Typical agent relay loop
-1. create_notification_rule targeting your agent_id
-2. Events arrive → Cairo enqueues pending notifications (webhook push retries on failure)
-3. get_pending_notifications → relay via your gateway using payload.channels
+1. setup_product (or create_notification_rule) targeting your agent_id
+2. Events arrive → Cairo enqueues pending notifications
+3. drain_notifications → relay via your gateway using channels{}
 4. ack_notification

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "packages/tracker",
         "packages/agent-mcp",
-        "packages/agent-tracker"
+        "packages/agent-tracker",
+        "packages/cairo-mcp"
       ],
       "dependencies": {
         "@google-cloud/secret-manager": "^5.0.0",
@@ -36,6 +37,22 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ani-hq/agent-mcp": {
+      "resolved": "packages/agent-mcp",
+      "link": true
+    },
+    "node_modules/@ani-hq/agent-tracker": {
+      "resolved": "packages/agent-tracker",
+      "link": true
+    },
+    "node_modules/@ani-hq/cairo-mcp": {
+      "resolved": "packages/cairo-mcp",
+      "link": true
+    },
+    "node_modules/@ani-hq/tracker": {
+      "resolved": "packages/tracker",
+      "link": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -588,18 +605,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@ani-hq/agent-mcp": {
-      "resolved": "packages/agent-mcp",
-      "link": true
-    },
-    "node_modules/@ani-hq/agent-tracker": {
-      "resolved": "packages/agent-tracker",
-      "link": true
-    },
-    "node_modules/@ani-hq/tracker": {
-      "resolved": "packages/tracker",
-      "link": true
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -4955,6 +4960,7 @@
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
       "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^4",
@@ -6566,7 +6572,7 @@
     },
     "packages/agent-mcp": {
       "name": "@ani-hq/agent-mcp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -6579,6 +6585,9 @@
         "@types/node": "^20.0.0",
         "@types/uuid": "^9.0.0",
         "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/agent-mcp/node_modules/@types/node": {
@@ -6600,7 +6609,7 @@
     },
     "packages/agent-tracker": {
       "name": "@ani-hq/agent-tracker",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "uuid": "^9.0.0"
@@ -6609,6 +6618,9 @@
         "@types/node": "^20.0.0",
         "@types/uuid": "^9.0.0",
         "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/agent-tracker/node_modules/@types/node": {
@@ -6628,9 +6640,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "packages/cairo-mcp": {
+      "name": "@ani-hq/cairo-mcp",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      },
+      "bin": {
+        "cairo-mcp": "index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "packages/tracker": {
       "name": "@ani-hq/tracker",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "uuid": "^9.0.0"
@@ -6639,6 +6665,9 @@
         "@types/node": "^20.0.0",
         "@types/uuid": "^9.0.0",
         "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/tracker/node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "workspaces": [
     "packages/tracker",
     "packages/agent-mcp",
-    "packages/agent-tracker"
+    "packages/agent-tracker",
+    "packages/cairo-mcp"
   ],
   "dependencies": {
     "@google-cloud/secret-manager": "^5.0.0",

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,23 +4,14 @@
 |---------|---------|
 | `@ani-hq/tracker` | Universal Segment-style tracker for apps |
 | `@ani-hq/agent-tracker` | Agent session / generation / tool-call SDK |
-| `@ani-hq/agent-mcp` | stdio MCP server for agent self-reporting |
+| `@ani-hq/agent-mcp` | stdio MCP for agent **self-telemetry** only |
+| `@ani-hq/cairo-mcp` | stdio MCP proxy to the **full** Cairo `/mcp` surface (setup, rules, drain) |
 
-All packages post to `${host}/v2/batch` (also available as `/api/v2/batch`).
-
-**Not yet published to npm.** See [docs/PUBLISHING.md](../docs/PUBLISHING.md).
-
-Build locally:
+Published on npm (`publishConfig.access: public`). See [docs/PUBLISHING.md](../docs/PUBLISHING.md).
 
 ```bash
 npm install
 npm run build
 ```
 
-Install from path:
-
-```bash
-npm install /path/to/cairo/packages/tracker
-```
-
-For the server's full MCP tool surface (events, notifications, GDPR, write keys), connect to `POST /mcp` on a running Cairo instance — that is separate from `@ani-hq/agent-mcp`.
+Turnkey agent path: [docs/AGENT_ONBOARDING.md](../docs/AGENT_ONBOARDING.md).

--- a/packages/cairo-mcp/.gitignore
+++ b/packages/cairo-mcp/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/cairo-mcp/README.md
+++ b/packages/cairo-mcp/README.md
@@ -1,0 +1,43 @@
+# @ani-hq/cairo-mcp
+
+stdio MCP server that proxies Cairo’s full HTTP `POST /mcp` surface (events, write keys, notification rules, pending drain, GDPR, etc.).
+
+Use this for **agent onboarding and notification relay**. For agent self-telemetry only, see `@ani-hq/agent-mcp`.
+
+## Install / run
+
+```bash
+npx -y @ani-hq/cairo-mcp
+```
+
+## Env
+
+| Var | Required | Description |
+|---|---|---|
+| `CAIRO_HOST` | yes | Cairo base URL |
+| `CAIRO_WRITE_KEY` | yes | Write key |
+| `CAIRO_AGENT_ID` | no | Default `agent_id` for setup / drain tools |
+
+## Cursor / Claude Code / OpenClaw
+
+```json
+{
+  "mcpServers": {
+    "cairo": {
+      "command": "npx",
+      "args": ["-y", "@ani-hq/cairo-mcp"],
+      "env": {
+        "CAIRO_HOST": "https://your-cairo-instance.com",
+        "CAIRO_WRITE_KEY": "ck_...",
+        "CAIRO_AGENT_ID": "my-agent"
+      }
+    }
+  }
+}
+```
+
+Then tell your agent:
+
+> Set up tracking for Product X. Notify me on signup, checkout, and errors.
+
+It should call `setup_product`, then later `drain_notifications` and relay via its own gateway.

--- a/packages/cairo-mcp/index.js
+++ b/packages/cairo-mcp/index.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+/**
+ * @ani-hq/cairo-mcp — stdio MCP proxy to Cairo's full HTTP /mcp surface.
+ *
+ * Env:
+ *   CAIRO_HOST       — base URL (required)
+ *   CAIRO_WRITE_KEY  — write key (required)
+ *   CAIRO_AGENT_ID   — optional default agent_id for setup/drain tools
+ */
+
+'use strict';
+
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+const {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} = require('@modelcontextprotocol/sdk/types.js');
+
+const HOST = (process.env.CAIRO_HOST || '').replace(/\/$/, '');
+const WRITE_KEY = process.env.CAIRO_WRITE_KEY || '';
+const AGENT_ID = process.env.CAIRO_AGENT_ID || '';
+
+if (!HOST || !WRITE_KEY) {
+  console.error(
+    '@ani-hq/cairo-mcp requires CAIRO_HOST and CAIRO_WRITE_KEY environment variables'
+  );
+  process.exit(1);
+}
+
+let rpcId = 1;
+
+async function cairoRpc(method, params) {
+  const body = {
+    jsonrpc: '2.0',
+    id: rpcId++,
+    method,
+  };
+  if (params !== undefined) body.params = params;
+
+  const res = await fetch(`${HOST}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Write-Key': WRITE_KEY,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const json = await res.json();
+  if (!res.ok) {
+    throw new Error(json.error?.message || `Cairo MCP HTTP ${res.status}`);
+  }
+  if (json.error) {
+    throw new Error(json.error.message || `Cairo MCP error ${json.error.code}`);
+  }
+  return json.result;
+}
+
+function withDefaultAgentId(name, args) {
+  if (!AGENT_ID) return args;
+  if (
+    [
+      'setup_product',
+      'drain_notifications',
+      'get_pending_notifications',
+      'enqueue_notification',
+      'register_agent_webhook',
+    ].includes(name) &&
+    (args.agent_id === undefined || args.agent_id === null || args.agent_id === '')
+  ) {
+    return { ...args, agent_id: AGENT_ID };
+  }
+  return args;
+}
+
+async function main() {
+  const server = new Server(
+    { name: 'cairo', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const result = await cairoRpc('tools/list');
+    return {
+      tools: (result.tools || []).map((t) => ({
+        name: t.name,
+        description: t.description || '',
+        inputSchema: t.inputSchema || { type: 'object', properties: {} },
+      })),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const name = request.params.name;
+    const rawArgs = request.params.arguments || {};
+    const args = withDefaultAgentId(name, rawArgs);
+
+    const result = await cairoRpc('tools/call', {
+      name,
+      arguments: args,
+    });
+
+    if (result?.content) {
+      return { content: result.content };
+    }
+    return {
+      content: [
+        {
+          type: 'text',
+          text: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/cairo-mcp/package.json
+++ b/packages/cairo-mcp/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@ani-hq/cairo-mcp",
+  "version": "1.0.0",
+  "description": "stdio MCP server that proxies the full Cairo HTTP /mcp surface for agents",
+  "main": "index.js",
+  "bin": {
+    "cairo-mcp": "./index.js"
+  },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/cairo-mcp",
+  "bugs": {
+    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [
+    "cairo",
+    "mcp",
+    "agent",
+    "notifications",
+    "model-context-protocol"
+  ],
+  "author": "Cairo Team",
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outcome-driven-studio/cairo.git",
+    "directory": "packages/cairo-mcp"
+  }
+}

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DRY_RUN="${DRY_RUN:-false}"
-PACKAGES=(tracker agent-tracker agent-mcp)
+PACKAGES=(tracker agent-tracker agent-mcp cairo-mcp)
 
 if [[ -n "${NPM_TOKEN:-}" ]]; then
   echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${HOME}/.npmrc-cairo-publish"
@@ -47,3 +47,4 @@ echo "==> Done"
 npm view @ani-hq/tracker version || true
 npm view @ani-hq/agent-tracker version || true
 npm view @ani-hq/agent-mcp version || true
+npm view @ani-hq/cairo-mcp version || true

--- a/skills/cairo-onboarding/SKILL.md
+++ b/skills/cairo-onboarding/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cairo-onboarding
+description: Set up Cairo product tracking and relay event notifications through the agent's own gateway. Use when the user asks to track product events, notify on signup/checkout/bugs, or connect a repo to Cairo.
+---
+
+# Cairo onboarding
+
+Cairo stores product/agent events and hands notifications to **you** (the agent). You relay via Discord/Slack/Telegram/etc. Cairo does not send to gateways.
+
+## Prerequisites
+
+MCP server `@ani-hq/cairo-mcp` configured with `CAIRO_HOST`, `CAIRO_WRITE_KEY`, and ideally `CAIRO_AGENT_ID`.
+
+## When the user asks to set up a product
+
+1. Call **`setup_product`** with:
+   - `product_name` — product or repo name
+   - `agent_id` — your id (from env if unset)
+   - `events` — list they named (e.g. signup, checkout_completed, error)
+   - optional `namespace`
+2. Return the **write_key** and install snippets from the response. Tell them to store the key securely (shown once).
+3. Do **not** invent Discord/Telegram API calls inside Cairo — use your own gateway after drain.
+
+## When the user asks for alerts / “anything happen?”
+
+1. Call **`drain_notifications`** with your `agent_id` (and namespace if known).
+2. Present each notification clearly in the channel you already use with the user.
+3. Call **`ack_notification`** for each id you delivered.
+
+## Do not
+
+- Ask the user to curl Cairo APIs if you can call MCP tools
+- Create product-specific agents inside Cairo — target your own `agent_id`
+- Claim Cairo posts to Discord/Telegram itself

--- a/src/routes/docsRoutes.js
+++ b/src/routes/docsRoutes.js
@@ -13,6 +13,7 @@ function renderDocs(baseUrl) {
   const tools = Object.values(mcp.tools);
 
   const categorize = (name) => {
+    if (name === "setup_product" || name === "drain_notifications") return "Onboarding";
     if (name.startsWith("gdpr_")) return "GDPR";
     if (name === "capture_error" || name.includes("error")) return "Error tracking";
     if (name.includes("notification") || name === "set_user_channel" || name === "enqueue_notification" || name === "ack_notification" || name === "register_agent_webhook" || name === "get_pending_notifications") {
@@ -31,7 +32,7 @@ function renderDocs(baseUrl) {
     (groups[cat] = groups[cat] || []).push(t);
   }
   const order = [
-    "Events", "Users", "Identity", "Error tracking", "Notifications",
+    "Onboarding", "Events", "Users", "Identity", "Error tracking", "Notifications",
     "GDPR", "Agent observability", "System",
   ];
 
@@ -261,16 +262,17 @@ ${toolSections}
   <tbody>
     <tr><td><code>@ani-hq/tracker</code></td><td>Universal event tracking from apps</td></tr>
     <tr><td><code>@ani-hq/agent-tracker</code></td><td>AI agent session tracking (generations, tool calls, costs)</td></tr>
-    <tr><td><code>@ani-hq/agent-mcp</code></td><td>stdio MCP server for agent self-reporting (not the full HTTP /mcp surface)</td></tr>
+    <tr><td><code>@ani-hq/cairo-mcp</code></td><td>stdio MCP proxy to the full HTTP /mcp surface (setup_product, drain, rules)</td></tr>
+    <tr><td><code>@ani-hq/agent-mcp</code></td><td>stdio MCP for agent self-reporting only</td></tr>
   </tbody>
 </table>
 
-<h3>stdio MCP for Claude Code / Cursor</h3>
+<h3>stdio MCP for Claude Code / Cursor / OpenClaw</h3>
 <pre>{
   "mcpServers": {
     "cairo": {
       "command": "npx",
-      "args": ["-y", "@ani-hq/agent-mcp"],
+      "args": ["-y", "@ani-hq/cairo-mcp"],
       "env": {
         "CAIRO_HOST": "${baseUrl}",
         "CAIRO_WRITE_KEY": "your-write-key",
@@ -279,6 +281,7 @@ ${toolSections}
     }
   }
 }</pre>
+<p>Then ask the agent to call <code>setup_product</code> and later <code>drain_notifications</code>.</p>
 
 <h2 id="selfhost">Self-hosting</h2>
 <p>Cairo is Node.js + PostgreSQL. MIT licensed.</p>

--- a/src/services/mcpService.js
+++ b/src/services/mcpService.js
@@ -333,6 +333,34 @@ class McpService {
       namespace: args.namespace || 'default',
     }));
 
+    register('setup_product', 'One-shot product onboarding: create a write key and notification rules for an agent. Returns the write key (once) plus install snippets for the product and MCP.', {
+      type: 'object',
+      properties: {
+        product_name: { type: 'string', description: 'Product / app name (used for key name and namespace default)' },
+        agent_id: { type: 'string', description: 'Agent that will relay notifications via its own gateway' },
+        events: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Event names to notify on (e.g. signup, checkout_completed)',
+        },
+        namespace: { type: 'string', description: 'Defaults to a slug of product_name' },
+        message_template: {
+          type: 'string',
+          description: 'Optional template for all rules. Supports {{event}}, {{userId}}, {{properties.x}}',
+        },
+      },
+      required: ['product_name', 'agent_id', 'events'],
+    }, this._toolSetupProduct);
+
+    register('drain_notifications', 'Pull pending notifications in a stable relay-ready shape (id, message, event, user, properties). Relay via your gateway, then ack_notification each id.', {
+      type: 'object',
+      properties: {
+        agent_id: { type: 'string' },
+        namespace: { type: 'string' },
+        limit: { type: 'number' },
+      },
+    }, this._toolDrainNotifications);
+
     // ── GDPR ───────────────────────────────────────────────────────────
     register('gdpr_delete_user', 'Delete all data for a user (GDPR).', {
       type: 'object',
@@ -652,6 +680,124 @@ class McpService {
       rate_limit: parseInt(process.env.CAIRO_RATE_LIMIT || '120', 10),
       tool_count: Object.keys(this.tools).length,
       timestamp: new Date().toISOString(),
+    };
+  }
+
+  _slugifyProduct(name) {
+    return String(name || 'product')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 48) || 'product';
+  }
+
+  async _toolSetupProduct(args) {
+    const productName = String(args.product_name || '').trim();
+    const agentId = String(args.agent_id || '').trim();
+    const events = Array.isArray(args.events) ? args.events.map((e) => String(e).trim()).filter(Boolean) : [];
+
+    if (!productName) throw new Error('product_name is required');
+    if (!agentId) throw new Error('agent_id is required');
+    if (!events.length) throw new Error('events must be a non-empty array of event names');
+
+    const namespace = (args.namespace && String(args.namespace).trim()) || this._slugifyProduct(productName);
+    const template =
+      args.message_template ||
+      `${productName}: {{event}} user={{userId}} {{properties}}`;
+
+    const { createWriteKey } = require('../middleware/auth');
+    const keyRow = await createWriteKey({ name: productName });
+
+    const rules = [];
+    for (const eventName of events) {
+      const rule = await this.notifications.createRule({
+        name: `${namespace}-${eventName}`,
+        event_name: eventName,
+        agent_id: agentId,
+        message_template: template,
+        namespace,
+      });
+      rules.push(rule);
+    }
+
+    const hostHint = process.env.BASE_URL || process.env.CAIRO_PUBLIC_URL || null;
+
+    return {
+      product_name: productName,
+      namespace,
+      agent_id: agentId,
+      write_key: keyRow.key,
+      write_key_id: keyRow.id,
+      host_hint: hostHint,
+      rules: rules.map((r) => ({
+        id: r.id,
+        name: r.name,
+        event_name: r.event_name,
+        agent_id: r.agent_id,
+        namespace: r.namespace,
+      })),
+      install: {
+        env: {
+          CAIRO_HOST: hostHint || 'https://your-cairo-instance.com',
+          CAIRO_WRITE_KEY: keyRow.key,
+          CAIRO_NAMESPACE: namespace,
+        },
+        tracker_snippet: [
+          "import { Cairo } from '@ani-hq/tracker';",
+          '',
+          'const cairo = Cairo.init({',
+          `  writeKey: '${keyRow.key}',`,
+          `  host: '${hostHint || 'https://your-cairo-instance.com'}',`,
+          '});',
+          '',
+          `cairo.track({ event: '${events[0]}', userId: 'user_123', properties: {} });`,
+        ].join('\n'),
+        mcp_snippet: {
+          mcpServers: {
+            cairo: {
+              command: 'npx',
+              args: ['-y', '@ani-hq/cairo-mcp'],
+              env: {
+                CAIRO_HOST: hostHint || 'https://your-cairo-instance.com',
+                CAIRO_WRITE_KEY: '<agent-ops-write-key>',
+                CAIRO_AGENT_ID: agentId,
+              },
+            },
+          },
+        },
+        note: 'Store write_key securely — it is returned only once. Product uses the product write key; the agent MCP uses an ops/agent write key from `cairo agent-config`.',
+      },
+    };
+  }
+
+  async _toolDrainNotifications(args) {
+    const agentId = args.agent_id || null;
+    const namespace = args.namespace || 'default';
+    const limit = Math.min(args.limit || 50, 200);
+    const rows = await this.notifications.getPendingNotifications({
+      agentId,
+      limit,
+      namespace,
+    });
+
+    return {
+      count: rows.length,
+      agent_id: agentId,
+      namespace,
+      notifications: rows.map((row) => {
+        const payload = row.payload || {};
+        return {
+          id: row.id,
+          message: row.message,
+          event: row.event_name || payload.event || null,
+          user: row.user_id || payload.userId || null,
+          properties: payload.properties || {},
+          channels: payload.channels || {},
+          created_at: row.created_at,
+          status: row.status,
+        };
+      }),
+      next_step: 'Relay each notification via your gateway, then call ack_notification with the id.',
     };
   }
 }

--- a/src/test/mcpRegistry.test.js
+++ b/src/test/mcpRegistry.test.js
@@ -20,6 +20,8 @@ describe('McpService registry', () => {
       'identify_user',
       'create_notification_rule',
       'get_pending_notifications',
+      'drain_notifications',
+      'setup_product',
       'ack_notification',
       'enqueue_notification',
       'register_agent_webhook',


### PR DESCRIPTION
## Summary
- New `@ani-hq/cairo-mcp` — stdio proxy to full HTTP `/mcp` (setup, rules, drain)
- Server tools: `setup_product`, `drain_notifications`
- CLI: `cairo agent-config` prints MCP JSON + mints ops write key
- Docs/skill: AGENT_ONBOARDING + `skills/cairo-onboarding`

## Test plan
- [x] MCP registry includes new tools
- [ ] Publish `@ani-hq/cairo-mcp@1.0.0`
- [ ] After merge: Cloud Run has setup_product
- [ ] Dash MCP → drain_notifications → Discord


Made with [Cursor](https://cursor.com)