### PR TITLE
feat(relay): proactive webhook relay with namespace fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cairo does **not** connect to messaging gateways itself.
 
 - **MCP-first.** Point any agent at Cairo; say “set this up for my product and ping me on signup.”
 - **Product events still work.** Frontend, backend, and mobile SDKs send to `/v2/track`.
-- **Agent handoff.** Rules enqueue for your `agent_id`. You pull (`drain_notifications`) or get a webhook, then relay on your gateway.
+- **Agent handoff.** Rules enqueue for your `agent_id`. Prefer webhook push to a thin relay (e.g. `@ani-hq/cairo-relay` → Discord); pull (`drain_notifications`) is the backup.
 - **Self-hosted.** Node.js + PostgreSQL.
 
 ## Turnkey (agent path)
@@ -31,7 +31,7 @@ Then tell your agent:
 
 > Set up tracking for Product X. Notify me on signup, checkout_completed, and errors.
 
-The agent calls **`setup_product`**, returns a product write key + install snippets. Later it **`drain_notifications`** and relays in Discord/Slack/etc.
+The agent calls **`setup_product`**, registers **`register_agent_webhook`** once at a thin relay, and returns a product write key + install snippets. Alerts arrive in Discord via the relay without asking the agent each time. **`drain_notifications`** remains for digests / backup.
 
 Full ritual: [docs/AGENT_ONBOARDING.md](./docs/AGENT_ONBOARDING.md) · skill: [skills/cairo-onboarding/SKILL.md](./skills/cairo-onboarding/SKILL.md)
 
@@ -97,13 +97,13 @@ product/agent  →  track event  →  Cairo stores event
          agent relays via its Telegram/Discord/Slack gateway
 ```
 
-Prefer **`setup_product`** for onboarding and **`drain_notifications`** for the relay loop. Lower-level tools: `create_notification_rule`, `get_pending_notifications`, `ack_notification`.
+Prefer **`setup_product`** + **`register_agent_webhook`** (→ cairo-relay) for proactive alerts. Use **`drain_notifications`** for digests or when the webhook is down. Lower-level tools: `create_notification_rule`, `get_pending_notifications`, `ack_notification`.
 
 ## MCP Tools
 
 | Category | Tools |
 |----------|-------|
-| **Onboarding** | `setup_product`, `drain_notifications` |
+| **Onboarding** | `setup_product`, `register_agent_webhook`, `drain_notifications` |
 | **Events** | `track_event`, `batch_track`, `query_events` |
 | **Users** | `identify_user`, `lookup_user` |
 | **Identity** | `resolve_identity`, `alias_identity` |

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -1,6 +1,18 @@
 # Agent onboarding (turnkey)
 
-Cairo is agent-first: **you talk to your agent**, the agent talks to Cairo, and the agent relays alerts through its own gateway (Discord, Slack, Telegram, etc.). Cairo never opens those gateways.
+Cairo is agent-first: **you talk to your agent**, the agent talks to Cairo, and alerts reach you through your gateway (Discord, Slack, Telegram, etc.). Cairo never opens those gateways itself.
+
+## Proactive path (recommended)
+
+When you say “let me know when someone signs up”:
+
+1. Agent calls **`setup_product`** (write key + notification rules).
+2. Agent ensures a **thin relay** webhook is registered once via **`register_agent_webhook`** (usually `namespace: "default"` so one URL covers all products).
+3. Product emits events → Cairo enqueues + **HTTP pushes** to the relay → relay batches → Discord → **`ack_notification`**.
+
+After setup, alerts arrive **without** you asking the agent. The agent is for setup and digests (“how many today?”), not the hot path. Do **not** use heartbeat/polling for every signup.
+
+See [`packages/cairo-relay`](../packages/cairo-relay/README.md).
 
 ## 1. Connect your agent (once)
 
@@ -49,6 +61,18 @@ The agent should call **`setup_product`** once with:
 
 It gets back a **product write key** (shown once) plus install snippets. Give the product that key and host.
 
+Then register the relay (once per agent):
+
+```text
+register_agent_webhook {
+  agent_id: "my-agent",
+  url: "https://your-relay-host/hooks/my-agent",
+  namespace: "default"
+}
+```
+
+Tell the user: you’ll ping their Discord channel when those events fire (via the relay).
+
 ## 3. Product emits events
 
 ```bash
@@ -63,22 +87,23 @@ cairo.track({ event: 'signup', userId: 'u1', properties: { plan: 'free' } });
 
 Or HTTP: `POST /v2/track` with `X-Write-Key`.
 
-## 4. Agent relays notifications
+## 4. Backup: pull / “any alerts?”
 
-On a schedule or when asked:
+If the webhook is down, or the user asks “any alerts?”, the agent can still:
 
 1. **`drain_notifications`** `{ agent_id }` (optional `namespace`)
 2. Post each `message` via the agent’s gateway
 3. **`ack_notification`** `{ id }` for each delivered row
 
-Optional: **`register_agent_webhook`** for push instead of pull.
+Pull is the backup path; webhook + relay is the proactive default.
 
 ## Ritual cheat sheet
 
-| Step | Tool |
+| Step | Tool / service |
 |---|---|
 | Onboard product | `setup_product` |
-| Pull alerts | `drain_notifications` |
-| Confirm delivery | `ack_notification` |
+| Proactive delivery | `register_agent_webhook` → **cairo-relay** → Discord |
+| Pull / digests | `drain_notifications` |
+| Confirm delivery | `ack_notification` (relay or agent) |
 | Add more rules later | `create_notification_rule` |
 | New ops key | `create_write_key` or `cairo agent-config` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "packages/tracker",
         "packages/agent-mcp",
         "packages/agent-tracker",
-        "packages/cairo-mcp"
+        "packages/cairo-mcp",
+        "packages/cairo-relay"
       ],
       "dependencies": {
         "@google-cloud/secret-manager": "^5.0.0",
@@ -48,6 +49,10 @@
     },
     "node_modules/@ani-hq/cairo-mcp": {
       "resolved": "packages/cairo-mcp",
+      "link": true
+    },
+    "node_modules/@ani-hq/cairo-relay": {
+      "resolved": "packages/cairo-relay",
       "link": true
     },
     "node_modules/@ani-hq/tracker": {
@@ -6649,6 +6654,17 @@
       },
       "bin": {
         "cairo-mcp": "index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cairo-relay": {
+      "name": "@ani-hq/cairo-relay",
+      "version": "1.0.0",
+      "license": "MIT",
+      "bin": {
+        "cairo-relay": "src/index.js"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "packages/tracker",
     "packages/agent-mcp",
     "packages/agent-tracker",
-    "packages/cairo-mcp"
+    "packages/cairo-mcp",
+    "packages/cairo-relay"
   ],
   "dependencies": {
     "@google-cloud/secret-manager": "^5.0.0",

--- a/packages/README.md
+++ b/packages/README.md
@@ -6,6 +6,7 @@
 | `@ani-hq/agent-tracker` | Agent session / generation / tool-call SDK |
 | `@ani-hq/agent-mcp` | stdio MCP for agent **self-telemetry** only |
 | `@ani-hq/cairo-mcp` | stdio MCP proxy to the **full** Cairo `/mcp` surface (setup, rules, drain) |
+| `@ani-hq/cairo-relay` | Thin webhook relay: Cairo push → batched Discord → ack (no LLM) |
 
 Published on npm (`publishConfig.access: public`). See [docs/PUBLISHING.md](../docs/PUBLISHING.md).
 

--- a/packages/cairo-relay/README.md
+++ b/packages/cairo-relay/README.md
@@ -1,0 +1,46 @@
+# @ani-hq/cairo-relay
+
+Thin, non-LLM relay: **Cairo webhook push → batch → Discord → ack**.
+
+At high volume it coalesces notifications (max N or T ms) so Discord stays readable and no model tokens are spent on the hot path.
+
+## Run
+
+```bash
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/... \
+# or: DISCORD_BOT_TOKEN=... DISCORD_CHANNEL_ID=...
+CAIRO_HOST=https://your-cairo-instance.com \
+CAIRO_WRITE_KEY=ck_... \
+HOOK_SECRET=optional-shared-secret \
+BATCH_MAX=10 \
+BATCH_MS=30000 \
+PORT=8790 \
+node src/index.js
+```
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/health` | Liveness |
+| `POST` | `/hooks/:agentId` | Cairo notification webhook target |
+
+Optional header: `X-Hook-Secret` (required when `HOOK_SECRET` is set). Set the same value as Cairo’s `CAIRO_WEBHOOK_SECRET` so pushes authenticate.
+
+## Register with Cairo
+
+```bash
+curl -X POST "$CAIRO_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -H "X-Write-Key: $CAIRO_WRITE_KEY" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
+    "name":"register_agent_webhook",
+    "arguments":{"agent_id":"dash","url":"https://your-host:8787/hooks/dash","namespace":"default"}
+  }}'
+```
+
+One `namespace=default` webhook covers all product namespaces (Cairo falls back to default).
+
+## Agent role
+
+Your conversational agent (e.g. Dash) still runs **setup** (`setup_product`, `register_agent_webhook`) and optional digests. It should **not** poll on a heartbeat for every signup — this relay owns the hot path.

--- a/packages/cairo-relay/deploy/cairo-relay.service.example
+++ b/packages/cairo-relay/deploy/cairo-relay.service.example
@@ -1,0 +1,43 @@
+# cairo-relay — systemd (holdco)
+
+```ini
+[Unit]
+Description=Cairo thin Discord notification relay
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/cairo-relay
+EnvironmentFile=/home/ubuntu/cairo-relay/.env
+ExecStart=/usr/bin/node /home/ubuntu/cairo-relay/src/index.js
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Copy to `/etc/systemd/system/cairo-relay.service`, then:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now cairo-relay
+sudo systemctl status cairo-relay
+```
+
+`.env` example:
+
+```bash
+PORT=8790
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+# or DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID
+CAIRO_HOST=https://cairo-cdp-6xknfazxaq-uc.a.run.app
+CAIRO_WRITE_KEY=ck_...
+HOOK_SECRET=
+BATCH_MAX=10
+BATCH_MS=30000
+```
+
+Expose via nginx/Caddy or Cloudflare tunnel so Cairo Cloud Run can reach `https://…/hooks/dash`.
+Example path on fleet: `https://fleet.ani.computer/cairo-hooks/dash` → `http://127.0.0.1:8790/hooks/dash`.

--- a/packages/cairo-relay/package.json
+++ b/packages/cairo-relay/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@ani-hq/cairo-relay",
+  "version": "1.0.0",
+  "description": "Thin webhook relay: Cairo notification push → batched Discord → ack",
+  "main": "src/index.js",
+  "bin": {
+    "cairo-relay": "./src/index.js"
+  },
+  "files": [
+    "src/",
+    "README.md"
+  ],
+  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/cairo-relay",
+  "bugs": {
+    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test test/*.test.js"
+  },
+  "keywords": [
+    "cairo",
+    "webhook",
+    "discord",
+    "notifications",
+    "relay"
+  ],
+  "author": "Cairo Team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outcome-driven-studio/cairo.git",
+    "directory": "packages/cairo-relay"
+  }
+}

--- a/packages/cairo-relay/src/batch.js
+++ b/packages/cairo-relay/src/batch.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * In-memory batch buffer keyed by agentId|event|channel.
+ * Flushes when size hits max OR timer elapses.
+ */
+class BatchBuffer {
+  /**
+   * @param {{ max?: number, ms?: number, onFlush: (key: string, items: object[]) => Promise<void> }} opts
+   */
+  constructor({ max = 10, ms = 30000, onFlush }) {
+    if (typeof onFlush !== 'function') throw new Error('onFlush required');
+    this.max = Math.max(1, max);
+    this.ms = Math.max(0, ms);
+    this.onFlush = onFlush;
+    /** @type {Map<string, { items: object[], timer: NodeJS.Timeout | null }>} */
+    this.buckets = new Map();
+  }
+
+  static key(agentId, event, channel = 'discord') {
+    return `${agentId || '_'}|${event || '_'}|${channel || 'discord'}`;
+  }
+
+  push(key, item) {
+    let bucket = this.buckets.get(key);
+    if (!bucket) {
+      bucket = { items: [], timer: null };
+      this.buckets.set(key, bucket);
+      if (this.ms > 0) {
+        bucket.timer = setTimeout(() => {
+          this._flushKey(key).catch(() => {});
+        }, this.ms);
+        if (typeof bucket.timer.unref === 'function') bucket.timer.unref();
+      }
+    }
+    bucket.items.push(item);
+    if (bucket.items.length >= this.max) {
+      return this._flushKey(key);
+    }
+    return Promise.resolve();
+  }
+
+  async flushAll() {
+    const keys = [...this.buckets.keys()];
+    for (const key of keys) {
+      await this._flushKey(key);
+    }
+  }
+
+  async _flushKey(key) {
+    const bucket = this.buckets.get(key);
+    if (!bucket || bucket.items.length === 0) {
+      this.buckets.delete(key);
+      return;
+    }
+    if (bucket.timer) {
+      clearTimeout(bucket.timer);
+      bucket.timer = null;
+    }
+    this.buckets.delete(key);
+    const items = bucket.items;
+    await this.onFlush(key, items);
+  }
+}
+
+module.exports = { BatchBuffer };

--- a/packages/cairo-relay/src/cairo.js
+++ b/packages/cairo-relay/src/cairo.js
@@ -1,0 +1,49 @@
+'use strict';
+
+let rpcId = 1;
+
+/**
+ * Call a Cairo MCP tool over HTTP JSON-RPC.
+ */
+async function callCairoTool(host, writeKey, name, args = {}) {
+  const base = String(host || '').replace(/\/$/, '');
+  if (!base) throw new Error('CAIRO_HOST required');
+  if (!writeKey) throw new Error('CAIRO_WRITE_KEY required');
+
+  const res = await fetch(`${base}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Write-Key': writeKey,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: rpcId++,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }),
+  });
+
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(json.error?.message || `Cairo MCP HTTP ${res.status}`);
+  }
+  if (json.error) {
+    throw new Error(json.error.message || `Cairo MCP error ${json.error.code}`);
+  }
+  return json.result;
+}
+
+async function ackNotification(host, writeKey, id, status = 'acked') {
+  return callCairoTool(host, writeKey, 'ack_notification', { id, status });
+}
+
+async function registerAgentWebhook(host, writeKey, { agentId, url, namespace = 'default' }) {
+  return callCairoTool(host, writeKey, 'register_agent_webhook', {
+    agent_id: agentId,
+    url,
+    namespace,
+  });
+}
+
+module.exports = { callCairoTool, ackNotification, registerAgentWebhook };

--- a/packages/cairo-relay/src/discord.js
+++ b/packages/cairo-relay/src/discord.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * Build Discord webhook content from one or more Cairo notifications.
+ */
+function formatDiscordContent(items) {
+  if (!items || items.length === 0) return '';
+  if (items.length === 1) {
+    const n = items[0].notification || items[0];
+    return String(n.message || n.event || 'notification').slice(0, 1900);
+  }
+
+  const event = items[0].notification?.event || items[0].event || 'events';
+  const lines = items.slice(0, 5).map((item) => {
+    const n = item.notification || item;
+    const msg = String(n.message || n.event || '').slice(0, 120);
+    return `• ${msg}`;
+  });
+  const more = items.length > 5 ? `\n…and ${items.length - 5} more` : '';
+  const header = `${items.length} new ${event} in this batch`;
+  return `${header}\n${lines.join('\n')}${more}`.slice(0, 1900);
+}
+
+async function postDiscordWebhook(webhookUrl, content) {
+  if (!webhookUrl) throw new Error('DISCORD_WEBHOOK_URL required');
+  if (!content) return { skipped: true };
+
+  const res = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Discord webhook ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return { ok: true };
+}
+
+/**
+ * Post via bot token + channel id when no incoming webhook is configured.
+ */
+async function postDiscordBot({ token, channelId, content }) {
+  if (!token || !channelId) throw new Error('DISCORD_BOT_TOKEN and DISCORD_CHANNEL_ID required');
+  if (!content) return { skipped: true };
+
+  const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bot ${token}`,
+    },
+    body: JSON.stringify({ content }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Discord bot post ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return { ok: true };
+}
+
+async function postDiscord(env, content) {
+  if (env.DISCORD_WEBHOOK_URL) {
+    return postDiscordWebhook(env.DISCORD_WEBHOOK_URL, content);
+  }
+  return postDiscordBot({
+    token: env.DISCORD_BOT_TOKEN,
+    channelId: env.DISCORD_CHANNEL_ID,
+    content,
+  });
+}
+
+module.exports = {
+  formatDiscordContent,
+  postDiscordWebhook,
+  postDiscordBot,
+  postDiscord,
+};

--- a/packages/cairo-relay/src/index.js
+++ b/packages/cairo-relay/src/index.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+'use strict';
+
+const { createApp } = require('./server');
+
+async function main() {
+  const required = ['CAIRO_HOST', 'CAIRO_WRITE_KEY'];
+  for (const key of required) {
+    if (!process.env[key]) {
+      console.error(`cairo-relay requires ${key}`);
+      process.exit(1);
+    }
+  }
+  const hasDiscord =
+    process.env.DISCORD_WEBHOOK_URL ||
+    (process.env.DISCORD_BOT_TOKEN && process.env.DISCORD_CHANNEL_ID);
+  if (!hasDiscord) {
+    console.error(
+      'cairo-relay requires DISCORD_WEBHOOK_URL or DISCORD_BOT_TOKEN+DISCORD_CHANNEL_ID'
+    );
+    process.exit(1);
+  }
+
+  const app = createApp(process.env);
+  await app.start();
+
+  const shutdown = async (signal) => {
+    console.log(`[cairo-relay] ${signal}, flushing…`);
+    try {
+      await app.stop();
+    } catch (err) {
+      console.error(err.message);
+    }
+    process.exit(0);
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { createApp };

--- a/packages/cairo-relay/src/server.js
+++ b/packages/cairo-relay/src/server.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const http = require('http');
+const { URL } = require('url');
+const { BatchBuffer } = require('./batch');
+const { formatDiscordContent, postDiscord } = require('./discord');
+const { ackNotification } = require('./cairo');
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(new Error('invalid JSON body'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+/**
+ * @param {object} env
+ */
+function createApp(env = process.env) {
+  const PORT = parseInt(env.PORT || '8787', 10);
+  const CAIRO_HOST = env.CAIRO_HOST || '';
+  const CAIRO_WRITE_KEY = env.CAIRO_WRITE_KEY || '';
+  const HOOK_SECRET = env.HOOK_SECRET || '';
+  const BATCH_MAX = parseInt(env.BATCH_MAX || '10', 10);
+  const BATCH_MS = parseInt(env.BATCH_MS || '30000', 10);
+
+  const buffer = new BatchBuffer({
+    max: BATCH_MAX,
+    ms: BATCH_MS,
+    onFlush: async (_key, items) => {
+      const content = formatDiscordContent(items);
+      await postDiscord(env, content);
+      for (const item of items) {
+        const id = item.notification?.id || item.id;
+        if (!id) continue;
+        try {
+          await ackNotification(CAIRO_HOST, CAIRO_WRITE_KEY, id, 'acked');
+        } catch (err) {
+          console.error(`[cairo-relay] ack failed for ${id}:`, err.message);
+        }
+      }
+    },
+  });
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+
+      if (req.method === 'GET' && url.pathname === '/health') {
+        return sendJson(res, 200, { ok: true, service: 'cairo-relay' });
+      }
+
+      const hookMatch = url.pathname.match(/^\/hooks\/([^/]+)$/);
+      if (req.method === 'POST' && hookMatch) {
+        if (HOOK_SECRET) {
+          const provided = req.headers['x-hook-secret'];
+          if (provided !== HOOK_SECRET) {
+            return sendJson(res, 401, { error: 'unauthorized' });
+          }
+        }
+
+        const agentId = decodeURIComponent(hookMatch[1]);
+        const body = await readJson(req);
+        const notification = body.notification || body;
+        if (!notification || (!notification.id && !notification.message)) {
+          return sendJson(res, 400, { error: 'notification required' });
+        }
+
+        const event = notification.event || body.event || '_';
+        const key = BatchBuffer.key(agentId, event, 'discord');
+        const item = {
+          agent_id: body.agent_id || agentId,
+          namespace: body.namespace || 'default',
+          notification,
+          receivedAt: new Date().toISOString(),
+        };
+
+        // Respond immediately; flush is async (batch or timer)
+        sendJson(res, 202, { accepted: true, agent_id: agentId, id: notification.id });
+        buffer.push(key, item).catch((err) => {
+          console.error('[cairo-relay] flush error:', err.message);
+        });
+        return;
+      }
+
+      sendJson(res, 404, { error: 'not found' });
+    } catch (err) {
+      console.error('[cairo-relay]', err.message);
+      sendJson(res, 500, { error: err.message || 'internal error' });
+    }
+  });
+
+  return {
+    server,
+    buffer,
+    PORT,
+    start() {
+      return new Promise((resolve) => {
+        server.listen(PORT, () => {
+          console.log(`[cairo-relay] listening on :${PORT}`);
+          resolve(server);
+        });
+      });
+    },
+    async stop() {
+      await buffer.flushAll();
+      await new Promise((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+module.exports = { createApp };

--- a/packages/cairo-relay/test/batch.test.js
+++ b/packages/cairo-relay/test/batch.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { BatchBuffer } = require('../src/batch');
+
+describe('BatchBuffer', () => {
+  it('flushes when max size reached', async () => {
+    const flushed = [];
+    const buf = new BatchBuffer({
+      max: 2,
+      ms: 60_000,
+      onFlush: async (key, items) => {
+        flushed.push({ key, items });
+      },
+    });
+
+    await buf.push('a|signup|discord', { id: 1 });
+    assert.equal(flushed.length, 0);
+    await buf.push('a|signup|discord', { id: 2 });
+    assert.equal(flushed.length, 1);
+    assert.equal(flushed[0].items.length, 2);
+  });
+
+  it('flushes on timer', async () => {
+    const flushed = [];
+    const buf = new BatchBuffer({
+      max: 10,
+      ms: 30,
+      onFlush: async (_key, items) => {
+        flushed.push(items);
+      },
+    });
+
+    await buf.push('a|signup|discord', { id: 1 });
+    await new Promise((r) => setTimeout(r, 80));
+    assert.equal(flushed.length, 1);
+    assert.equal(flushed[0][0].id, 1);
+  });
+});

--- a/packages/cairo-relay/test/discord.test.js
+++ b/packages/cairo-relay/test/discord.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { formatDiscordContent } = require('../src/discord');
+
+describe('formatDiscordContent', () => {
+  it('uses message for a single notification', () => {
+    const out = formatDiscordContent([
+      { notification: { id: '1', event: 'signup', message: 'New signup: u1' } },
+    ]);
+    assert.equal(out, 'New signup: u1');
+  });
+
+  it('coalesces multiple into a batch summary', () => {
+    const items = [1, 2, 3].map((i) => ({
+      notification: { id: String(i), event: 'signup', message: `user ${i} signed up` },
+    }));
+    const out = formatDiscordContent(items);
+    assert.match(out, /3 new signup/);
+    assert.match(out, /user 1 signed up/);
+  });
+});

--- a/skills/cairo-onboarding/SKILL.md
+++ b/skills/cairo-onboarding/SKILL.md
@@ -1,34 +1,37 @@
 ---
 name: cairo-onboarding
-description: Set up Cairo product tracking and relay event notifications through the agent's own gateway. Use when the user asks to track product events, notify on signup/checkout/bugs, or connect a repo to Cairo.
+description: Set up Cairo product tracking and proactive Discord alerts via webhook relay. Use when the user asks to track product events, notify on signup/checkout/bugs, or connect a repo to Cairo.
 ---
 
 # Cairo onboarding
 
-Cairo stores product/agent events and hands notifications to **you** (the agent). You relay via Discord/Slack/Telegram/etc. Cairo does not send to gateways.
+Cairo stores product/agent events and hands notifications to agents. **Proactive delivery** uses Cairo’s webhook push into a thin relay (batched Discord + ack). You (the conversational agent) own setup and digests — not a per-event LLM loop or heartbeat poll.
 
 ## Prerequisites
 
-MCP server `@ani-hq/cairo-mcp` configured with `CAIRO_HOST`, `CAIRO_WRITE_KEY`, and ideally `CAIRO_AGENT_ID`.
+MCP server `@ani-hq/cairo-mcp` configured with `CAIRO_HOST`, `CAIRO_WRITE_KEY`, and ideally `CAIRO_AGENT_ID`.  
+A running **cairo-relay** (or equivalent) that posts to Discord and acks.
 
-## When the user asks to set up a product
+## When the user asks to set up a product / “let me know when…”
 
 1. Call **`setup_product`** with:
    - `product_name` — product or repo name
    - `agent_id` — your id (from env if unset)
    - `events` — list they named (e.g. signup, checkout_completed, error)
    - optional `namespace`
-2. Return the **write_key** and install snippets from the response. Tell them to store the key securely (shown once).
-3. Do **not** invent Discord/Telegram API calls inside Cairo — use your own gateway after drain.
+2. Ensure **`register_agent_webhook`** once for your `agent_id` pointing at the relay  
+   (`url: https://…/hooks/<agent_id>`, `namespace: "default"` so one webhook covers all products).
+3. Return the **write_key** and install snippets. Tell them alerts will ping their Discord channel when those events fire — they do not need to ask you each time.
+4. Do **not** invent Discord API calls inside Cairo, and do **not** add heartbeat polling for this.
 
-## When the user asks for alerts / “anything happen?”
+## When the user asks for alerts / “anything happen?” / digests
 
-1. Call **`drain_notifications`** with your `agent_id` (and namespace if known).
-2. Present each notification clearly in the channel you already use with the user.
-3. Call **`ack_notification`** for each id you delivered.
+1. Prefer summarizing what already went to Discord if you know; otherwise call **`drain_notifications`** with your `agent_id`.
+2. Present clearly; **`ack_notification`** any ids you deliver that the relay has not already acked.
 
 ## Do not
 
 - Ask the user to curl Cairo APIs if you can call MCP tools
 - Create product-specific agents inside Cairo — target your own `agent_id`
-- Claim Cairo posts to Discord/Telegram itself
+- Claim Cairo posts to Discord itself (the **relay** does)
+- Use heartbeat / scheduled LLM turns as the primary signup alert path

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -241,11 +241,7 @@ class NotificationService {
 
     let url;
     try {
-      const result = await query(
-        `SELECT webhook_url FROM agent_endpoints WHERE agent_id = $1 AND namespace = $2`,
-        [agentId, namespace]
-      );
-      url = result.rows[0]?.webhook_url;
+      url = await this._resolveAgentWebhook(agentId, namespace || 'default');
     } catch (err) {
       logger.warn(`[notifications] agent endpoint lookup failed:`, err.message);
       return { pushed: false, reason: 'lookup_failed' };
@@ -255,6 +251,8 @@ class NotificationService {
 
     const body = {
       type: 'notification',
+      agent_id: agentId,
+      namespace: namespace || 'default',
       notification: {
         id: notification.id,
         event: notification.event_name,
@@ -266,10 +264,14 @@ class NotificationService {
       },
     };
 
+    const headers = { 'Content-Type': 'application/json' };
+    const hookSecret = process.env.CAIRO_WEBHOOK_SECRET;
+    if (hookSecret) headers['X-Hook-Secret'] = hookSecret;
+
     let lastError = null;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        await axios.post(url, body, { timeout: 8000 });
+        await axios.post(url, body, { timeout: 8000, headers });
         return { pushed: true, attempts: attempt };
       } catch (err) {
         lastError = err.response?.data?.message || err.message;
@@ -291,6 +293,25 @@ class NotificationService {
     } catch (_) { /* */ }
 
     return { pushed: false, reason: 'exhausted', error: lastError, attempts: maxAttempts };
+  }
+
+  /**
+   * Resolve webhook URL for an agent: exact namespace first, then default.
+   * One registered default webhook can cover all product namespaces.
+   */
+  async _resolveAgentWebhook(agentId, namespace) {
+    const ns = namespace || 'default';
+    const primary = await query(
+      `SELECT webhook_url FROM agent_endpoints WHERE agent_id = $1 AND namespace = $2`,
+      [agentId, ns]
+    );
+    if (primary.rows[0]?.webhook_url) return primary.rows[0].webhook_url;
+    if (ns === 'default') return null;
+    const fallback = await query(
+      `SELECT webhook_url FROM agent_endpoints WHERE agent_id = $1 AND namespace = 'default'`,
+      [agentId]
+    );
+    return fallback.rows[0]?.webhook_url || null;
   }
 
   /**

--- a/src/test/notifications.test.js
+++ b/src/test/notifications.test.js
@@ -1,4 +1,10 @@
-const { renderTemplate } = require('../notifications');
+jest.mock('../utils/db', () => ({
+  query: jest.fn(),
+}));
+
+const { query } = require('../utils/db');
+const NotificationService = require('../notifications');
+const { renderTemplate } = NotificationService;
 
 describe('renderTemplate', () => {
   it('interpolates event and nested properties', () => {
@@ -15,7 +21,6 @@ describe('renderTemplate', () => {
 });
 
 describe('NotificationService matching', () => {
-  const NotificationService = require('../notifications');
   const svc = new NotificationService();
 
   it('matches when property_match is null', () => {
@@ -25,5 +30,39 @@ describe('NotificationService matching', () => {
   it('matches exact property filters', () => {
     expect(svc._matchesProperties({ plan: 'pro' }, { plan: 'pro' })).toBe(true);
     expect(svc._matchesProperties({ plan: 'pro' }, { plan: 'free' })).toBe(false);
+  });
+});
+
+describe('_resolveAgentWebhook namespace fallback', () => {
+  const svc = new NotificationService();
+
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  it('returns exact namespace webhook when present', async () => {
+    query.mockResolvedValueOnce({ rows: [{ webhook_url: 'https://relay/hooks/dash' }] });
+    await expect(svc._resolveAgentWebhook('dash', 'adventures-of')).resolves.toBe(
+      'https://relay/hooks/dash'
+    );
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][1]).toEqual(['dash', 'adventures-of']);
+  });
+
+  it('falls back to default namespace when exact miss', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ webhook_url: 'https://relay/hooks/dash' }] });
+    await expect(svc._resolveAgentWebhook('dash', 'adventures-of')).resolves.toBe(
+      'https://relay/hooks/dash'
+    );
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[1][1]).toEqual(['dash']);
+  });
+
+  it('does not double-query when namespace is already default', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    await expect(svc._resolveAgentWebhook('dash', 'default')).resolves.toBeNull();
+    expect(query).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Fall back agent webhook lookup to `namespace=default` so one Dash webhook covers all product namespaces
- Add `@ani-hq/cairo-relay`: Cairo push → batch (N or T) → Discord → ack (no LLM)
- Document webhook-first proactive onboarding; pull remains backup/digests

## Test plan
- [x] Unit tests for `_resolveAgentWebhook` fallback
- [x] cairo-relay batch + Discord format tests
- [ ] Deploy relay on holdco; `register_agent_webhook` for dash
- [ ] Smoke: track signup → Discord without asking Dash


Made with [Cursor](https://cursor.com)