### PR TITLE
docs(oss): gateway-agnostic relay and launch-ready polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ LOG_LEVEL=info
 # Agent webhook push retries
 # CAIRO_WEBHOOK_RETRIES=3
 # CAIRO_WEBHOOK_RETRY_DELAY_MS=250
+# Optional shared secret sent as X-Hook-Secret on agent webhook pushes
+# CAIRO_WEBHOOK_SECRET=
 
 # Optional: Sentry
 # SENTRY_DSN=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,9 @@ INSERT INTO write_keys (key, name) VALUES ('dev-key', 'local');
 
 - Primary interface: `POST /mcp`
 - Product ingest: `POST /v2/track` / `POST /v2/batch` (also under `/api/v2`)
-- Notifications hand off to agents; agents relay via their own gateways
-- Packages live under `packages/` (workspaces): `@ani-hq/tracker`, `@ani-hq/agent-tracker`, `@ani-hq/agent-mcp`
+- Notifications hand off to agents; agents relay via their own gateways (Cairo never talks to Slack/Discord/etc.)
+- Packages live under `packages/` (workspaces): `@ani-hq/tracker`, `@ani-hq/agent-tracker`, `@ani-hq/agent-mcp`, `@ani-hq/cairo-mcp`, `@ani-hq/cairo-relay`
+- Keep examples gateway-agnostic — no product- or fleet-specific hostnames in docs
 
 ## License
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Cairo Contributors
+Copyright (c) 2024–2026 Cairo Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,19 +1,31 @@
 # Cairo
 
-Open-source, agent-first event tracking. Agents are the primary user. Track events from products and agents, then hand notifications to agents who relay to end users via their own gateways (Telegram, Discord, Slack, WhatsApp, etc.).
+**Agent-first event tracking.** Products and agents emit events; Cairo stores them and hands matching notifications to your agents. Agents relay through **their own** gateways (Slack, Discord, Telegram, WhatsApp, email, …).
 
-Cairo does **not** connect to messaging gateways itself.
+Cairo does **not** connect to messaging platforms.
 
-> **Status:** dogfood / early production. Self-host from git. Client packages: `@ani-hq/tracker`, `@ani-hq/agent-tracker`, `@ani-hq/agent-mcp`, `@ani-hq/cairo-mcp`.
+```text
+your product ──track──▶ Cairo ──rule match──▶ pending queue
+                                              │
+                         webhook push ────────┤
+                                              ▼
+                                    thin relay (optional)
+                                              │
+                                              ▼
+                                 your Slack / Discord / …
+```
+
+> Self-host from git. npm clients: `@ani-hq/tracker`, `@ani-hq/agent-tracker`, `@ani-hq/cairo-mcp`, `@ani-hq/agent-mcp`, `@ani-hq/cairo-relay`.
 
 ## Why Cairo
 
 - **MCP-first.** Point any agent at Cairo; say “set this up for my product and ping me on signup.”
-- **Product events still work.** Frontend, backend, and mobile SDKs send to `/v2/track`.
-- **Agent handoff.** Rules enqueue for your `agent_id`. Prefer webhook push to a thin relay (e.g. `@ani-hq/cairo-relay` → Discord); pull (`drain_notifications`) is the backup.
-- **Self-hosted.** Node.js + PostgreSQL.
+- **Product events still work.** SDKs and `POST /v2/track` for apps.
+- **Agent handoff, not CDP fan-out.** Rules target an `agent_id`. Prefer webhook push to a thin relay; pull (`drain_notifications`) is the backup.
+- **Gateway-agnostic.** Cairo POSTs JSON to *your* URL. Use `@ani-hq/cairo-relay`, or any worker you already run.
+- **Self-hosted.** Node.js + PostgreSQL. MIT licensed.
 
-## Turnkey (agent path)
+## Quick start
 
 ```bash
 git clone https://github.com/outcome-driven-studio/cairo.git
@@ -25,24 +37,27 @@ npm install && npm run migrate && npm start
 node bin/cairo.js agent-config --host https://your-cairo-instance.com --agent-id my-agent
 ```
 
-Paste the JSON into Cursor / Claude Code / OpenClaw / Hermes (`@ani-hq/cairo-mcp`).
+Paste the JSON into Cursor, Claude Code, OpenClaw, Hermes, or any MCP client (`@ani-hq/cairo-mcp`).
 
 Then tell your agent:
 
 > Set up tracking for Product X. Notify me on signup, checkout_completed, and errors.
 
-The agent calls **`setup_product`**, registers **`register_agent_webhook`** once at a thin relay, and returns a product write key + install snippets. Alerts arrive in Discord via the relay without asking the agent each time. **`drain_notifications`** remains for digests / backup.
+The agent calls **`setup_product`**, registers **`register_agent_webhook`** once at your relay, and returns a product write key + install snippets. Alerts reach your channel via the relay **without** asking the agent each time. Use **`drain_notifications`** for digests or when the webhook is down.
 
 Full ritual: [docs/AGENT_ONBOARDING.md](./docs/AGENT_ONBOARDING.md) · skill: [skills/cairo-onboarding/SKILL.md](./skills/cairo-onboarding/SKILL.md)
 
 Production tip: set `NODE_ENV=production` (or `CAIRO_REQUIRE_WRITE_KEYS=true`) so bootstrap mode is disabled.
 
-### Agent MCP packages
+### Packages
 
 | Package | Use |
 |---------|-----|
-| `@ani-hq/cairo-mcp` | **Full surface** — setup, rules, drain, GDPR, events |
+| `@ani-hq/cairo-mcp` | **Full MCP surface** — setup, rules, drain, GDPR, events |
 | `@ani-hq/agent-mcp` | Agent self-telemetry only (generations, tool calls) |
+| `@ani-hq/tracker` | App / product event SDK |
+| `@ani-hq/agent-tracker` | Agent session / generation SDK |
+| `@ani-hq/cairo-relay` | Optional thin relay: push → batch → your webhook/Slack/Discord → ack |
 
 ```json
 {
@@ -60,7 +75,7 @@ Production tip: set `NODE_ENV=production` (or `CAIRO_REQUIRE_WRITE_KEYS=true`) s
 }
 ```
 
-### For Apps (SDK)
+### Product SDK
 
 ```bash
 npm install @ani-hq/tracker
@@ -92,14 +107,14 @@ product/agent  →  track event  →  Cairo stores event
                                       ↓
                          enqueue for agent_id
                                       ↓
-              agent drains (MCP) or receives webhook push
+              webhook push (preferred)  or  agent drain (backup)
                                       ↓
-         agent relays via its Telegram/Discord/Slack gateway
+              your relay / agent  →  Slack, Discord, Telegram, …
 ```
 
-Prefer **`setup_product`** + **`register_agent_webhook`** (→ cairo-relay) for proactive alerts. Use **`drain_notifications`** for digests or when the webhook is down. Lower-level tools: `create_notification_rule`, `get_pending_notifications`, `ack_notification`.
+Prefer **`setup_product`** + **`register_agent_webhook`**. Lower-level tools: `create_notification_rule`, `get_pending_notifications`, `ack_notification`.
 
-## MCP Tools
+## MCP tools
 
 | Category | Tools |
 |----------|-------|
@@ -139,8 +154,12 @@ node bin/cairo.js list-write-keys
 node bin/cairo.js revoke-write-key --id <id>
 ```
 
-Useful env vars: see [`.env.example`](./.env.example). Rate limit defaults to 120 req/min per write key. Agent webhook push retries 3 times with backoff (`CAIRO_WEBHOOK_RETRIES`).
+Env: [`.env.example`](./.env.example). Rate limit defaults to 120 req/min per write key. Webhook push retries with backoff (`CAIRO_WEBHOOK_RETRIES`). Optional shared secret: `CAIRO_WEBHOOK_SECRET` → `X-Hook-Secret`.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md). Security: [SECURITY.md](./SECURITY.md).
 
 ## License
 
-MIT
+[MIT](./LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied on the latest `main` branch. Self-hosters should stay current with `main` (or tagged releases when published).
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security problems.
+
+Email the maintainers via the contact listed on the [GitHub organization](https://github.com/outcome-driven-studio) or open a **private** security advisory on the repository if available.
+
+Include:
+
+- Description and impact
+- Steps to reproduce
+- Affected commit / version if known
+
+We will acknowledge receipt and work on a fix before any public disclosure.
+
+## Hardening checklist (self-host)
+
+- Set `NODE_ENV=production` or `CAIRO_REQUIRE_WRITE_KEYS=true` (disable bootstrap / open ingest)
+- Rotate write keys; never commit `.env` / secrets
+- Put TLS in front of Cairo and any relay
+- Optionally set `CAIRO_WEBHOOK_SECRET` and matching `HOOK_SECRET` on relays
+- Restrict who can call MCP tools that mint keys or delete user data

--- a/docs/AGENT_ONBOARDING.md
+++ b/docs/AGENT_ONBOARDING.md
@@ -1,18 +1,18 @@
 # Agent onboarding (turnkey)
 
-Cairo is agent-first: **you talk to your agent**, the agent talks to Cairo, and alerts reach you through your gateway (Discord, Slack, Telegram, etc.). Cairo never opens those gateways itself.
+Cairo is agent-first: **you talk to your agent**, the agent talks to Cairo, and alerts reach you through **your** gateway (Discord, Slack, Telegram, WhatsApp, email worker, etc.). Cairo never opens those gateways itself.
 
 ## Proactive path (recommended)
 
 When you say “let me know when someone signs up”:
 
 1. Agent calls **`setup_product`** (write key + notification rules).
-2. Agent ensures a **thin relay** webhook is registered once via **`register_agent_webhook`** (usually `namespace: "default"` so one URL covers all products).
-3. Product emits events → Cairo enqueues + **HTTP pushes** to the relay → relay batches → Discord → **`ack_notification`**.
+2. Agent ensures a relay webhook is registered once via **`register_agent_webhook`** (usually `namespace: "default"` so one URL covers all products).
+3. Product emits events → Cairo enqueues + **HTTP pushes** to your relay → relay batches → your gateway → **`ack_notification`**.
 
 After setup, alerts arrive **without** you asking the agent. The agent is for setup and digests (“how many today?”), not the hot path. Do **not** use heartbeat/polling for every signup.
 
-See [`packages/cairo-relay`](../packages/cairo-relay/README.md).
+Reference relay (optional): [`packages/cairo-relay`](../packages/cairo-relay/README.md) — forwards to a generic HTTPS webhook, Slack, Discord, or stdout. You can also implement the same contract in any language.
 
 ## 1. Connect your agent (once)
 
@@ -24,7 +24,7 @@ POSTGRES_URL=... node bin/cairo.js agent-config \
   --agent-id my-agent
 ```
 
-Paste the printed MCP JSON into Cursor, Claude Code, OpenClaw, or Hermes.
+Paste the printed MCP JSON into Cursor, Claude Code, OpenClaw, Hermes, or any MCP client.
 
 Or manually:
 
@@ -66,12 +66,12 @@ Then register the relay (once per agent):
 ```text
 register_agent_webhook {
   agent_id: "my-agent",
-  url: "https://your-relay-host/hooks/my-agent",
+  url: "https://relay.example.com/hooks/my-agent",
   namespace: "default"
 }
 ```
 
-Tell the user: you’ll ping their Discord channel when those events fire (via the relay).
+Tell the user: you’ll ping their preferred channel when those events fire (via the relay / their gateway).
 
 ## 3. Product emits events
 
@@ -102,7 +102,7 @@ Pull is the backup path; webhook + relay is the proactive default.
 | Step | Tool / service |
 |---|---|
 | Onboard product | `setup_product` |
-| Proactive delivery | `register_agent_webhook` → **cairo-relay** → Discord |
+| Proactive delivery | `register_agent_webhook` → **your relay** → your gateway |
 | Pull / digests | `drain_notifications` |
 | Confirm delivery | `ack_notification` (relay or agent) |
 | Add more rules later | `create_notification_rule` |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -28,3 +28,4 @@ Or Actions → **Publish npm packages** → Run workflow.
 - `@ani-hq/agent-tracker`
 - `@ani-hq/agent-mcp`
 - `@ani-hq/cairo-mcp`
+- `@ani-hq/cairo-relay`

--- a/llms.txt
+++ b/llms.txt
@@ -12,9 +12,12 @@ Auth: X-Write-Key header (or Authorization: Bearer <key>)
 2. Agent MCP package: `npx -y @ani-hq/cairo-mcp` (full surface). Not `@ani-hq/agent-mcp` (telemetry only).
 3. User says: set up Product X; notify on signup / checkout / errors
 4. Agent calls `setup_product` → returns product write_key + install snippets
-5. Product posts to `/v2/track` with that key
-6. Agent calls `drain_notifications` → relays via its gateway → `ack_notification`
+5. Agent registers `register_agent_webhook` once (namespace=default) at a thin relay URL
+6. Product posts to `/v2/track` with that key
+7. Cairo pushes notifications to the relay → relay batches → your gateway → `ack_notification`
+8. Backup / digests: `drain_notifications` → relay via agent gateway → `ack_notification`
 
+Optional reference relay: `@ani-hq/cairo-relay` (generic FORWARD_URL, Slack, Discord, or stdout).
 Docs: GET /docs · GET /llms.txt · docs/AGENT_ONBOARDING.md
 
 ## Discovery
@@ -31,6 +34,8 @@ JSON-RPC 2.0. Methods: initialize, tools/list, tools/call, ping.
 ### Onboarding
 - setup_product { product_name, agent_id, events[], namespace?, message_template? }
   Creates a product write key + one rule per event. Returns write_key (once) and install snippets.
+- register_agent_webhook { agent_id, url, namespace? }
+  Push target for proactive delivery. namespace=default covers all product namespaces (fallback).
 - drain_notifications { agent_id?, namespace?, limit? }
   Pending notifications in relay-ready shape: id, message, event, user, properties, channels.
 
@@ -96,9 +101,11 @@ JSON-RPC 2.0. Methods: initialize, tools/list, tools/call, ping.
 - NODE_ENV=production or CAIRO_REQUIRE_WRITE_KEYS=true disables bootstrap
 - Create keys: CLI `cairo create-write-key --name prod` or MCP create_write_key
 - Agent install: `cairo agent-config --host <url> --agent-id <id>`
+- Optional CAIRO_WEBHOOK_SECRET sent as X-Hook-Secret on agent webhook pushes
 
-## Typical agent relay loop
-1. setup_product (or create_notification_rule) targeting your agent_id
-2. Events arrive → Cairo enqueues pending notifications
-3. drain_notifications → relay via your gateway using channels{}
-4. ack_notification
+## Typical proactive path
+1. setup_product targeting your agent_id
+2. register_agent_webhook → your relay URL (namespace=default)
+3. Events arrive → Cairo enqueues + HTTP pushes
+4. Relay batches → your gateway → ack_notification
+5. Digests / backup: drain_notifications → your gateway → ack_notification

--- a/packages/README.md
+++ b/packages/README.md
@@ -6,7 +6,7 @@
 | `@ani-hq/agent-tracker` | Agent session / generation / tool-call SDK |
 | `@ani-hq/agent-mcp` | stdio MCP for agent **self-telemetry** only |
 | `@ani-hq/cairo-mcp` | stdio MCP proxy to the **full** Cairo `/mcp` surface (setup, rules, drain) |
-| `@ani-hq/cairo-relay` | Thin webhook relay: Cairo push → batched Discord → ack (no LLM) |
+| `@ani-hq/cairo-relay` | Optional thin relay: Cairo push → batch → your webhook/Slack/Discord → ack (no LLM) |
 
 Published on npm (`publishConfig.access: public`). See [docs/PUBLISHING.md](../docs/PUBLISHING.md).
 

--- a/packages/cairo-mcp/README.md
+++ b/packages/cairo-mcp/README.md
@@ -40,4 +40,4 @@ Then tell your agent:
 
 > Set up tracking for Product X. Notify me on signup, checkout, and errors.
 
-It should call `setup_product`, then later `drain_notifications` and relay via its own gateway.
+It should call `setup_product`, register a webhook (`register_agent_webhook`) for proactive delivery, and use `drain_notifications` for digests or backup. Relays go through the agent’s own gateway — Cairo never talks to Slack/Discord/etc.

--- a/packages/cairo-relay/README.md
+++ b/packages/cairo-relay/README.md
@@ -1,31 +1,51 @@
 # @ani-hq/cairo-relay
 
-Thin, non-LLM relay: **Cairo webhook push → batch → Discord → ack**.
+Thin, **non-LLM** relay for Cairo’s agent webhook push:
 
-At high volume it coalesces notifications (max N or T ms) so Discord stays readable and no model tokens are spent on the hot path.
+**Cairo → batch → your gateway → ack**
+
+Cairo never talks to Discord, Slack, Telegram, etc. This optional package is one way to turn the push into a message on *your* channel. Point it at a generic HTTP webhook, Slack incoming webhook, Discord, or stdout.
+
+At high volume it coalesces notifications (max N **or** T ms) so chat stays readable and no model tokens are spent on the hot path.
+
+## Destinations
+
+| Mode | Env | Notes |
+|------|-----|--------|
+| Generic / Slack webhook | `FORWARD_URL` (or `WEBHOOK_URL`) | JSON POST. Set `WEBHOOK_STYLE=slack` for `{ "text": "..." }` only |
+| Discord | `DISCORD_WEBHOOK_URL` **or** `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` | Optional adapter |
+| Stdout | `DESTINATION=stdout` | Local / debug |
+
+Or set `DESTINATION=webhook|discord|stdout` explicitly.
 
 ## Run
 
 ```bash
-DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/... \
-# or: DISCORD_BOT_TOKEN=... DISCORD_CHANNEL_ID=...
+# Example: forward to any HTTPS endpoint (Slack, custom worker, …)
+FORWARD_URL=https://hooks.example.com/incoming \
 CAIRO_HOST=https://your-cairo-instance.com \
 CAIRO_WRITE_KEY=ck_... \
 HOOK_SECRET=optional-shared-secret \
 BATCH_MAX=10 \
 BATCH_MS=30000 \
 PORT=8790 \
-node src/index.js
+npx -y @ani-hq/cairo-relay
+```
+
+From this repo:
+
+```bash
+cd packages/cairo-relay && npm start
 ```
 
 ## Endpoints
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| `GET` | `/health` | Liveness |
+| `GET` | `/health` | Liveness (+ resolved destination) |
 | `POST` | `/hooks/:agentId` | Cairo notification webhook target |
 
-Optional header: `X-Hook-Secret` (required when `HOOK_SECRET` is set). Set the same value as Cairo’s `CAIRO_WEBHOOK_SECRET` so pushes authenticate.
+Optional header: `X-Hook-Secret` (required when `HOOK_SECRET` is set). Match Cairo’s `CAIRO_WEBHOOK_SECRET` if you enable it.
 
 ## Register with Cairo
 
@@ -35,7 +55,11 @@ curl -X POST "$CAIRO_HOST/mcp" \
   -H "X-Write-Key: $CAIRO_WRITE_KEY" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
     "name":"register_agent_webhook",
-    "arguments":{"agent_id":"dash","url":"https://your-host:8787/hooks/dash","namespace":"default"}
+    "arguments":{
+      "agent_id":"my-agent",
+      "url":"https://relay.example.com/hooks/my-agent",
+      "namespace":"default"
+    }
   }}'
 ```
 
@@ -43,4 +67,8 @@ One `namespace=default` webhook covers all product namespaces (Cairo falls back 
 
 ## Agent role
 
-Your conversational agent (e.g. Dash) still runs **setup** (`setup_product`, `register_agent_webhook`) and optional digests. It should **not** poll on a heartbeat for every signup — this relay owns the hot path.
+Your conversational agent still owns **setup** (`setup_product`, `register_agent_webhook`) and optional digests (“how many today?”). It should **not** poll on a heartbeat for every signup — this relay owns the hot path.
+
+## Deploy
+
+See [deploy/cairo-relay.service.example](./deploy/cairo-relay.service.example) for a sample systemd unit. Expose `/hooks/:agentId` over HTTPS so your Cairo host can reach it.

--- a/packages/cairo-relay/deploy/cairo-relay.service.example
+++ b/packages/cairo-relay/deploy/cairo-relay.service.example
@@ -1,43 +1,38 @@
-# cairo-relay — systemd (holdco)
+# cairo-relay — sample systemd unit
+#
+# 1. Copy the package to e.g. /opt/cairo-relay
+# 2. Create /opt/cairo-relay/.env (see below)
+# 3. Install this unit and start the service
+# 4. Put HTTPS in front (Caddy, nginx, Cloudflare Tunnel, …)
+# 5. register_agent_webhook → https://relay.example.com/hooks/<agent_id>
 
-```ini
 [Unit]
-Description=Cairo thin Discord notification relay
+Description=Cairo notification relay (batch → your gateway → ack)
 After=network.target
 
 [Service]
 Type=simple
-User=ubuntu
-WorkingDirectory=/home/ubuntu/cairo-relay
-EnvironmentFile=/home/ubuntu/cairo-relay/.env
-ExecStart=/usr/bin/node /home/ubuntu/cairo-relay/src/index.js
+User=cairo
+WorkingDirectory=/opt/cairo-relay
+EnvironmentFile=/opt/cairo-relay/.env
+ExecStart=/usr/bin/node /opt/cairo-relay/src/index.js
 Restart=always
 RestartSec=3
 
 [Install]
 WantedBy=multi-user.target
-```
 
-Copy to `/etc/systemd/system/cairo-relay.service`, then:
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now cairo-relay
-sudo systemctl status cairo-relay
-```
-
-`.env` example:
-
-```bash
-PORT=8790
-DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
-# or DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID
-CAIRO_HOST=https://cairo-cdp-6xknfazxaq-uc.a.run.app
-CAIRO_WRITE_KEY=ck_...
-HOOK_SECRET=
-BATCH_MAX=10
-BATCH_MS=30000
-```
-
-Expose via nginx/Caddy or Cloudflare tunnel so Cairo Cloud Run can reach `https://…/hooks/dash`.
-Example path on fleet: `https://fleet.ani.computer/cairo-hooks/dash` → `http://127.0.0.1:8790/hooks/dash`.
+# --- /opt/cairo-relay/.env example ---
+#
+# PORT=8790
+# CAIRO_HOST=https://your-cairo-instance.com
+# CAIRO_WRITE_KEY=ck_...
+# HOOK_SECRET=
+# BATCH_MAX=10
+# BATCH_MS=30000
+#
+# Pick one destination:
+#   FORWARD_URL=https://hooks.example.com/incoming
+#   WEBHOOK_STYLE=slack          # optional; Slack-compatible { text }
+#   DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+#   DESTINATION=stdout           # debug

--- a/packages/cairo-relay/package.json
+++ b/packages/cairo-relay/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@ani-hq/cairo-relay",
-  "version": "1.0.0",
-  "description": "Thin webhook relay: Cairo notification push → batched Discord → ack",
+  "version": "1.1.0",
+  "description": "Thin webhook relay: Cairo notification push → batch → your gateway → ack",
   "main": "src/index.js",
   "bin": {
     "cairo-relay": "./src/index.js"
   },
   "files": [
     "src/",
-    "README.md"
+    "README.md",
+    "deploy/"
   ],
   "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/cairo-relay",
   "bugs": {
@@ -27,9 +28,11 @@
   "keywords": [
     "cairo",
     "webhook",
-    "discord",
     "notifications",
-    "relay"
+    "relay",
+    "agents",
+    "discord",
+    "slack"
   ],
   "author": "Cairo Team",
   "license": "MIT",

--- a/packages/cairo-relay/src/batch.js
+++ b/packages/cairo-relay/src/batch.js
@@ -17,8 +17,8 @@ class BatchBuffer {
     this.buckets = new Map();
   }
 
-  static key(agentId, event, channel = 'discord') {
-    return `${agentId || '_'}|${event || '_'}|${channel || 'discord'}`;
+  static key(agentId, event, channel = 'default') {
+    return `${agentId || '_'}|${event || '_'}|${channel || 'default'}`;
   }
 
   push(key, item) {

--- a/packages/cairo-relay/src/destinations.js
+++ b/packages/cairo-relay/src/destinations.js
@@ -1,0 +1,137 @@
+'use strict';
+
+/**
+ * Pluggable delivery adapters for cairo-relay.
+ *
+ * Resolve order (first match wins):
+ *   1. DESTINATION env (webhook | discord | stdout)
+ *   2. FORWARD_URL / WEBHOOK_URL → webhook
+ *   3. DISCORD_WEBHOOK_URL or DISCORD_BOT_TOKEN+CHANNEL → discord
+ *   4. else → error
+ */
+
+async function deliverWebhook(url, content, items, { style } = {}) {
+  if (!url) throw new Error('FORWARD_URL (or WEBHOOK_URL) required');
+  if (!content) return { skipped: true };
+
+  const payload =
+    style === 'slack'
+      ? { text: content }
+      : {
+          text: content,
+          content,
+          count: items.length,
+          notifications: items.map((item) => item.notification || item),
+        };
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`forward webhook ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return { ok: true, destination: 'webhook' };
+}
+
+async function deliverDiscord(env, content) {
+  if (!content) return { skipped: true };
+
+  if (env.DISCORD_WEBHOOK_URL) {
+    const res = await fetch(env.DISCORD_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Discord webhook ${res.status}: ${text.slice(0, 200)}`);
+    }
+    return { ok: true, destination: 'discord' };
+  }
+
+  const token = env.DISCORD_BOT_TOKEN;
+  const channelId = env.DISCORD_CHANNEL_ID;
+  if (!token || !channelId) {
+    throw new Error('DISCORD_WEBHOOK_URL or DISCORD_BOT_TOKEN+DISCORD_CHANNEL_ID required');
+  }
+
+  const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bot ${token}`,
+    },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Discord bot post ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return { ok: true, destination: 'discord' };
+}
+
+async function deliverStdout(content, items) {
+  console.log(
+    JSON.stringify({
+      type: 'cairo-relay',
+      content,
+      count: items.length,
+      ids: items.map((i) => i.notification?.id || i.id).filter(Boolean),
+    })
+  );
+  return { ok: true, destination: 'stdout' };
+}
+
+function resolveDestination(env = process.env) {
+  const explicit = (env.DESTINATION || '').toLowerCase().trim();
+  if (explicit) return explicit;
+
+  if (env.FORWARD_URL || env.WEBHOOK_URL) return 'webhook';
+  if (
+    env.DISCORD_WEBHOOK_URL ||
+    (env.DISCORD_BOT_TOKEN && env.DISCORD_CHANNEL_ID)
+  ) {
+    return 'discord';
+  }
+  return null;
+}
+
+function assertDestinationConfigured(env = process.env) {
+  const dest = resolveDestination(env);
+  if (!dest) {
+    throw new Error(
+      'cairo-relay needs a destination: set FORWARD_URL, or DISCORD_WEBHOOK_URL, or DESTINATION=stdout'
+    );
+  }
+  return dest;
+}
+
+/**
+ * Deliver formatted content for a flushed batch.
+ */
+async function deliver(env, content, items) {
+  const dest = assertDestinationConfigured(env);
+
+  if (dest === 'stdout') return deliverStdout(content, items);
+  if (dest === 'discord') return deliverDiscord(env, content);
+  if (dest === 'webhook') {
+    const url = env.FORWARD_URL || env.WEBHOOK_URL;
+    const style = (env.WEBHOOK_STYLE || '').toLowerCase() === 'slack' ? 'slack' : 'generic';
+    return deliverWebhook(url, content, items, { style });
+  }
+
+  throw new Error(`unknown DESTINATION: ${dest} (use webhook | discord | stdout)`);
+}
+
+module.exports = {
+  resolveDestination,
+  assertDestinationConfigured,
+  deliver,
+  deliverWebhook,
+  deliverDiscord,
+  deliverStdout,
+};

--- a/packages/cairo-relay/src/discord.js
+++ b/packages/cairo-relay/src/discord.js
@@ -1,80 +1,22 @@
 'use strict';
 
 /**
- * Build Discord webhook content from one or more Cairo notifications.
+ * Discord adapter — thin re-export for backwards compatibility.
+ * Prefer `destinations.js` + `format.js` for new code.
  */
+
+const { formatMessage } = require('./format');
+const { deliverDiscord } = require('./destinations');
+
 function formatDiscordContent(items) {
-  if (!items || items.length === 0) return '';
-  if (items.length === 1) {
-    const n = items[0].notification || items[0];
-    return String(n.message || n.event || 'notification').slice(0, 1900);
-  }
-
-  const event = items[0].notification?.event || items[0].event || 'events';
-  const lines = items.slice(0, 5).map((item) => {
-    const n = item.notification || item;
-    const msg = String(n.message || n.event || '').slice(0, 120);
-    return `• ${msg}`;
-  });
-  const more = items.length > 5 ? `\n…and ${items.length - 5} more` : '';
-  const header = `${items.length} new ${event} in this batch`;
-  return `${header}\n${lines.join('\n')}${more}`.slice(0, 1900);
-}
-
-async function postDiscordWebhook(webhookUrl, content) {
-  if (!webhookUrl) throw new Error('DISCORD_WEBHOOK_URL required');
-  if (!content) return { skipped: true };
-
-  const res = await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`Discord webhook ${res.status}: ${text.slice(0, 200)}`);
-  }
-  return { ok: true };
-}
-
-/**
- * Post via bot token + channel id when no incoming webhook is configured.
- */
-async function postDiscordBot({ token, channelId, content }) {
-  if (!token || !channelId) throw new Error('DISCORD_BOT_TOKEN and DISCORD_CHANNEL_ID required');
-  if (!content) return { skipped: true };
-
-  const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bot ${token}`,
-    },
-    body: JSON.stringify({ content }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`Discord bot post ${res.status}: ${text.slice(0, 200)}`);
-  }
-  return { ok: true };
+  return formatMessage(items);
 }
 
 async function postDiscord(env, content) {
-  if (env.DISCORD_WEBHOOK_URL) {
-    return postDiscordWebhook(env.DISCORD_WEBHOOK_URL, content);
-  }
-  return postDiscordBot({
-    token: env.DISCORD_BOT_TOKEN,
-    channelId: env.DISCORD_CHANNEL_ID,
-    content,
-  });
+  return deliverDiscord(env, content);
 }
 
 module.exports = {
   formatDiscordContent,
-  postDiscordWebhook,
-  postDiscordBot,
   postDiscord,
 };

--- a/packages/cairo-relay/src/format.js
+++ b/packages/cairo-relay/src/format.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Format one or more Cairo notifications into a plain-text message.
+ * Gateway-agnostic — destinations decide how to send the string.
+ */
+function formatMessage(items) {
+  if (!items || items.length === 0) return '';
+  if (items.length === 1) {
+    const n = items[0].notification || items[0];
+    return String(n.message || n.event || 'notification').slice(0, 1900);
+  }
+
+  const event = items[0].notification?.event || items[0].event || 'events';
+  const lines = items.slice(0, 5).map((item) => {
+    const n = item.notification || item;
+    const msg = String(n.message || n.event || '').slice(0, 120);
+    return `• ${msg}`;
+  });
+  const more = items.length > 5 ? `\n…and ${items.length - 5} more` : '';
+  const header = `${items.length} new ${event} in this batch`;
+  return `${header}\n${lines.join('\n')}${more}`.slice(0, 1900);
+}
+
+module.exports = { formatMessage };

--- a/packages/cairo-relay/src/index.js
+++ b/packages/cairo-relay/src/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const { createApp } = require('./server');
+const { assertDestinationConfigured } = require('./destinations');
 
 async function main() {
   const required = ['CAIRO_HOST', 'CAIRO_WRITE_KEY'];
@@ -11,13 +12,11 @@ async function main() {
       process.exit(1);
     }
   }
-  const hasDiscord =
-    process.env.DISCORD_WEBHOOK_URL ||
-    (process.env.DISCORD_BOT_TOKEN && process.env.DISCORD_CHANNEL_ID);
-  if (!hasDiscord) {
-    console.error(
-      'cairo-relay requires DISCORD_WEBHOOK_URL or DISCORD_BOT_TOKEN+DISCORD_CHANNEL_ID'
-    );
+
+  try {
+    assertDestinationConfigured(process.env);
+  } catch (err) {
+    console.error(err.message);
     process.exit(1);
   }
 

--- a/packages/cairo-relay/src/server.js
+++ b/packages/cairo-relay/src/server.js
@@ -3,7 +3,8 @@
 const http = require('http');
 const { URL } = require('url');
 const { BatchBuffer } = require('./batch');
-const { formatDiscordContent, postDiscord } = require('./discord');
+const { formatMessage } = require('./format');
+const { deliver, resolveDestination } = require('./destinations');
 const { ackNotification } = require('./cairo');
 
 function readJson(req) {
@@ -36,19 +37,20 @@ function sendJson(res, status, body) {
  * @param {object} env
  */
 function createApp(env = process.env) {
-  const PORT = parseInt(env.PORT || '8787', 10);
+  const PORT = parseInt(env.PORT || '8790', 10);
   const CAIRO_HOST = env.CAIRO_HOST || '';
   const CAIRO_WRITE_KEY = env.CAIRO_WRITE_KEY || '';
   const HOOK_SECRET = env.HOOK_SECRET || '';
   const BATCH_MAX = parseInt(env.BATCH_MAX || '10', 10);
   const BATCH_MS = parseInt(env.BATCH_MS || '30000', 10);
+  const destination = resolveDestination(env) || 'unset';
 
   const buffer = new BatchBuffer({
     max: BATCH_MAX,
     ms: BATCH_MS,
     onFlush: async (_key, items) => {
-      const content = formatDiscordContent(items);
-      await postDiscord(env, content);
+      const content = formatMessage(items);
+      await deliver(env, content, items);
       for (const item of items) {
         const id = item.notification?.id || item.id;
         if (!id) continue;
@@ -66,7 +68,11 @@ function createApp(env = process.env) {
       const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
 
       if (req.method === 'GET' && url.pathname === '/health') {
-        return sendJson(res, 200, { ok: true, service: 'cairo-relay' });
+        return sendJson(res, 200, {
+          ok: true,
+          service: 'cairo-relay',
+          destination,
+        });
       }
 
       const hookMatch = url.pathname.match(/^\/hooks\/([^/]+)$/);
@@ -86,7 +92,7 @@ function createApp(env = process.env) {
         }
 
         const event = notification.event || body.event || '_';
-        const key = BatchBuffer.key(agentId, event, 'discord');
+        const key = BatchBuffer.key(agentId, event, destination);
         const item = {
           agent_id: body.agent_id || agentId,
           namespace: body.namespace || 'default',
@@ -94,7 +100,6 @@ function createApp(env = process.env) {
           receivedAt: new Date().toISOString(),
         };
 
-        // Respond immediately; flush is async (batch or timer)
         sendJson(res, 202, { accepted: true, agent_id: agentId, id: notification.id });
         buffer.push(key, item).catch((err) => {
           console.error('[cairo-relay] flush error:', err.message);
@@ -113,10 +118,11 @@ function createApp(env = process.env) {
     server,
     buffer,
     PORT,
+    destination,
     start() {
       return new Promise((resolve) => {
         server.listen(PORT, () => {
-          console.log(`[cairo-relay] listening on :${PORT}`);
+          console.log(`[cairo-relay] listening on :${PORT} (destination=${destination})`);
           resolve(server);
         });
       });

--- a/packages/cairo-relay/test/batch.test.js
+++ b/packages/cairo-relay/test/batch.test.js
@@ -15,9 +15,9 @@ describe('BatchBuffer', () => {
       },
     });
 
-    await buf.push('a|signup|discord', { id: 1 });
+    await buf.push('a|signup|default', { id: 1 });
     assert.equal(flushed.length, 0);
-    await buf.push('a|signup|discord', { id: 2 });
+    await buf.push('a|signup|default', { id: 2 });
     assert.equal(flushed.length, 1);
     assert.equal(flushed[0].items.length, 2);
   });
@@ -32,7 +32,7 @@ describe('BatchBuffer', () => {
       },
     });
 
-    await buf.push('a|signup|discord', { id: 1 });
+    await buf.push('a|signup|default', { id: 1 });
     await new Promise((r) => setTimeout(r, 80));
     assert.equal(flushed.length, 1);
     assert.equal(flushed[0][0].id, 1);

--- a/packages/cairo-relay/test/destinations.test.js
+++ b/packages/cairo-relay/test/destinations.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveDestination, assertDestinationConfigured } = require('../src/destinations');
+
+describe('resolveDestination', () => {
+  it('prefers explicit DESTINATION', () => {
+    assert.equal(resolveDestination({ DESTINATION: 'stdout', FORWARD_URL: 'https://x' }), 'stdout');
+  });
+
+  it('uses FORWARD_URL as webhook', () => {
+    assert.equal(resolveDestination({ FORWARD_URL: 'https://hooks.example/x' }), 'webhook');
+  });
+
+  it('detects discord credentials', () => {
+    assert.equal(
+      resolveDestination({ DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/x' }),
+      'discord'
+    );
+  });
+
+  it('throws when nothing configured', () => {
+    assert.throws(() => assertDestinationConfigured({}), /destination/i);
+  });
+});

--- a/packages/cairo-relay/test/format.test.js
+++ b/packages/cairo-relay/test/format.test.js
@@ -2,11 +2,11 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { formatDiscordContent } = require('../src/discord');
+const { formatMessage } = require('../src/format');
 
-describe('formatDiscordContent', () => {
+describe('formatMessage', () => {
   it('uses message for a single notification', () => {
-    const out = formatDiscordContent([
+    const out = formatMessage([
       { notification: { id: '1', event: 'signup', message: 'New signup: u1' } },
     ]);
     assert.equal(out, 'New signup: u1');
@@ -16,7 +16,7 @@ describe('formatDiscordContent', () => {
     const items = [1, 2, 3].map((i) => ({
       notification: { id: String(i), event: 'signup', message: `user ${i} signed up` },
     }));
-    const out = formatDiscordContent(items);
+    const out = formatMessage(items);
     assert.match(out, /3 new signup/);
     assert.match(out, /user 1 signed up/);
   });

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DRY_RUN="${DRY_RUN:-false}"
-PACKAGES=(tracker agent-tracker agent-mcp cairo-mcp)
+PACKAGES=(tracker agent-tracker agent-mcp cairo-mcp cairo-relay)
 
 if [[ -n "${NPM_TOKEN:-}" ]]; then
   echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${HOME}/.npmrc-cairo-publish"
@@ -48,3 +48,4 @@ npm view @ani-hq/tracker version || true
 npm view @ani-hq/agent-tracker version || true
 npm view @ani-hq/agent-mcp version || true
 npm view @ani-hq/cairo-mcp version || true
+npm view @ani-hq/cairo-relay version || true

--- a/skills/cairo-onboarding/SKILL.md
+++ b/skills/cairo-onboarding/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: cairo-onboarding
-description: Set up Cairo product tracking and proactive Discord alerts via webhook relay. Use when the user asks to track product events, notify on signup/checkout/bugs, or connect a repo to Cairo.
+description: Set up Cairo product tracking and proactive alerts via webhook relay to the agent's own gateway. Use when the user asks to track product events, notify on signup/checkout/bugs, or connect a repo to Cairo.
 ---
 
 # Cairo onboarding
 
-Cairo stores product/agent events and hands notifications to agents. **Proactive delivery** uses Cairo’s webhook push into a thin relay (batched Discord + ack). You (the conversational agent) own setup and digests — not a per-event LLM loop or heartbeat poll.
+Cairo stores product/agent events and hands notifications to **you** (the agent). **Proactive delivery** uses Cairo’s webhook push into a thin relay (batch → your gateway → ack). You own setup and digests — not a per-event LLM loop or heartbeat poll.
 
 ## Prerequisites
 
 MCP server `@ani-hq/cairo-mcp` configured with `CAIRO_HOST`, `CAIRO_WRITE_KEY`, and ideally `CAIRO_AGENT_ID`.  
-A running **cairo-relay** (or equivalent) that posts to Discord and acks.
+A running relay that implements Cairo’s webhook contract (e.g. `@ani-hq/cairo-relay`, or your own) and posts through **your** gateway.
 
 ## When the user asks to set up a product / “let me know when…”
 
@@ -21,17 +21,17 @@ A running **cairo-relay** (or equivalent) that posts to Discord and acks.
    - optional `namespace`
 2. Ensure **`register_agent_webhook`** once for your `agent_id` pointing at the relay  
    (`url: https://…/hooks/<agent_id>`, `namespace: "default"` so one webhook covers all products).
-3. Return the **write_key** and install snippets. Tell them alerts will ping their Discord channel when those events fire — they do not need to ask you each time.
-4. Do **not** invent Discord API calls inside Cairo, and do **not** add heartbeat polling for this.
+3. Return the **write_key** and install snippets. Tell them alerts will reach their channel when those events fire — they do not need to ask you each time.
+4. Do **not** invent gateway API calls inside Cairo, and do **not** add heartbeat polling for this.
 
 ## When the user asks for alerts / “anything happen?” / digests
 
-1. Prefer summarizing what already went to Discord if you know; otherwise call **`drain_notifications`** with your `agent_id`.
+1. Prefer summarizing what already went to their channel if you know; otherwise call **`drain_notifications`** with your `agent_id`.
 2. Present clearly; **`ack_notification`** any ids you deliver that the relay has not already acked.
 
 ## Do not
 
 - Ask the user to curl Cairo APIs if you can call MCP tools
 - Create product-specific agents inside Cairo — target your own `agent_id`
-- Claim Cairo posts to Discord itself (the **relay** does)
+- Claim Cairo posts to Discord/Slack/Telegram itself (the **relay / your gateway** does)
 - Use heartbeat / scheduled LLM turns as the primary signup alert path

--- a/src/routes/docsRoutes.js
+++ b/src/routes/docsRoutes.js
@@ -264,6 +264,7 @@ ${toolSections}
     <tr><td><code>@ani-hq/agent-tracker</code></td><td>AI agent session tracking (generations, tool calls, costs)</td></tr>
     <tr><td><code>@ani-hq/cairo-mcp</code></td><td>stdio MCP proxy to the full HTTP /mcp surface (setup_product, drain, rules)</td></tr>
     <tr><td><code>@ani-hq/agent-mcp</code></td><td>stdio MCP for agent self-reporting only</td></tr>
+    <tr><td><code>@ani-hq/cairo-relay</code></td><td>Optional thin relay: webhook push → batch → your gateway → ack</td></tr>
   </tbody>
 </table>
 
@@ -281,7 +282,7 @@ ${toolSections}
     }
   }
 }</pre>
-<p>Then ask the agent to call <code>setup_product</code> and later <code>drain_notifications</code>.</p>
+<p>Ask the agent to call <code>setup_product</code> and <code>register_agent_webhook</code> for proactive delivery. Use <code>drain_notifications</code> for digests or backup.</p>
 
 <h2 id="selfhost">Self-hosting</h2>
 <p>Cairo is Node.js + PostgreSQL. MIT licensed.</p>

--- a/src/test/notifications.test.js
+++ b/src/test/notifications.test.js
@@ -41,28 +41,28 @@ describe('_resolveAgentWebhook namespace fallback', () => {
   });
 
   it('returns exact namespace webhook when present', async () => {
-    query.mockResolvedValueOnce({ rows: [{ webhook_url: 'https://relay/hooks/dash' }] });
-    await expect(svc._resolveAgentWebhook('dash', 'adventures-of')).resolves.toBe(
-      'https://relay/hooks/dash'
+    query.mockResolvedValueOnce({ rows: [{ webhook_url: 'https://relay.example/hooks/my-agent' }] });
+    await expect(svc._resolveAgentWebhook('my-agent', 'product-a')).resolves.toBe(
+      'https://relay.example/hooks/my-agent'
     );
     expect(query).toHaveBeenCalledTimes(1);
-    expect(query.mock.calls[0][1]).toEqual(['dash', 'adventures-of']);
+    expect(query.mock.calls[0][1]).toEqual(['my-agent', 'product-a']);
   });
 
   it('falls back to default namespace when exact miss', async () => {
     query
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ webhook_url: 'https://relay/hooks/dash' }] });
-    await expect(svc._resolveAgentWebhook('dash', 'adventures-of')).resolves.toBe(
-      'https://relay/hooks/dash'
+      .mockResolvedValueOnce({ rows: [{ webhook_url: 'https://relay.example/hooks/my-agent' }] });
+    await expect(svc._resolveAgentWebhook('my-agent', 'product-a')).resolves.toBe(
+      'https://relay.example/hooks/my-agent'
     );
     expect(query).toHaveBeenCalledTimes(2);
-    expect(query.mock.calls[1][1]).toEqual(['dash']);
+    expect(query.mock.calls[1][1]).toEqual(['my-agent']);
   });
 
   it('does not double-query when namespace is already default', async () => {
     query.mockResolvedValueOnce({ rows: [] });
-    await expect(svc._resolveAgentWebhook('dash', 'default')).resolves.toBeNull();
+    await expect(svc._resolveAgentWebhook('my-agent', 'default')).resolves.toBeNull();
     expect(query).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Make `@ani-hq/cairo-relay` destination-pluggable (`FORWARD_URL` / Slack / Discord / stdout) — Discord is optional, not the product
- Scrub Dash/holdco/fleet hostnames from docs and examples
- Add SECURITY.md; update README, onboarding, llms.txt, CONTRIBUTING, publishing for public launch

## Test plan
- [x] `jest` notification tests
- [x] `cairo-relay` node:test suite
- [x] ripgrep: no holdco/fleet.ani refs in docs


Made with [Cursor](https://cursor.com)