### PR TITLE
chore: point docs and packages at Ani-HQ org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Be respectful, constructive, and collaborative.
 ## Development Setup
 
 ```bash
-git clone git@github.com:outcome-driven-studio/cairo.git
+git clone git@github.com:Ani-HQ/cairo.git
 cd cairo
 cp .env.example .env.local
 # set POSTGRES_URL

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ your product ──track──▶ Cairo ──rule match──▶ pending queue
 ## Quick start
 
 ```bash
-git clone https://github.com/outcome-driven-studio/cairo.git
+git clone https://github.com/Ani-HQ/cairo.git
 cd cairo
 cp .env.example .env.local   # set POSTGRES_URL
 npm install && npm run migrate && npm start

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Security fixes are applied on the latest `main` branch. Self-hosters should stay
 
 Please **do not** open a public GitHub issue for security problems.
 
-Email the maintainers via the contact listed on the [GitHub organization](https://github.com/outcome-driven-studio) or open a **private** security advisory on the repository if available.
+Email the maintainers via the contact listed on the [GitHub organization](https://github.com/Ani-HQ) or open a **private** security advisory on the repository if available.
 
 Include:
 

--- a/docs/EVENT_TRACKING_QUICK_REFERENCE.md
+++ b/docs/EVENT_TRACKING_QUICK_REFERENCE.md
@@ -133,7 +133,7 @@ const result = await trackedGenerate({ model, prompt });
 ## Server Setup (self-hosting)
 
 ```bash
-git clone https://github.com/outcome-driven-studio/cairo.git
+git clone https://github.com/Ani-HQ/cairo.git
 cd cairo
 npm install
 npm run setup    # creates database tables

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/outcome-driven-studio/cairo.git"
+    "url": "https://github.com/Ani-HQ/cairo.git"
   },
   "workspaces": [
     "packages/tracker",

--- a/packages/agent-mcp/README.md
+++ b/packages/agent-mcp/README.md
@@ -1,6 +1,6 @@
 # @ani-hq/agent-mcp
 
-stdio [MCP](https://modelcontextprotocol.io) server for agent self-reporting into [Cairo](https://github.com/outcome-driven-studio/cairo).
+stdio [MCP](https://modelcontextprotocol.io) server for agent self-reporting into [Cairo](https://github.com/Ani-HQ/cairo).
 
 ```bash
 npx -y @ani-hq/agent-mcp

--- a/packages/agent-mcp/package.json
+++ b/packages/agent-mcp/package.json
@@ -11,9 +11,9 @@
     "dist",
     "README.md"
   ],
-  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/agent-mcp",
+  "homepage": "https://github.com/Ani-HQ/cairo/tree/main/packages/agent-mcp",
   "bugs": {
-    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+    "url": "https://github.com/Ani-HQ/cairo/issues"
   },
   "engines": {
     "node": ">=18"
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/outcome-driven-studio/cairo.git",
+    "url": "git+https://github.com/Ani-HQ/cairo.git",
     "directory": "packages/agent-mcp"
   }
 }

--- a/packages/agent-tracker/README.md
+++ b/packages/agent-tracker/README.md
@@ -1,6 +1,6 @@
 # @ani-hq/agent-tracker
 
-Track AI agent sessions, LLM generations, tool calls, decisions, and errors into [Cairo](https://github.com/outcome-driven-studio/cairo).
+Track AI agent sessions, LLM generations, tool calls, decisions, and errors into [Cairo](https://github.com/Ani-HQ/cairo).
 
 ```bash
 npm install @ani-hq/agent-tracker

--- a/packages/agent-tracker/package.json
+++ b/packages/agent-tracker/package.json
@@ -8,9 +8,9 @@
     "dist",
     "README.md"
   ],
-  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/agent-tracker",
+  "homepage": "https://github.com/Ani-HQ/cairo/tree/main/packages/agent-tracker",
   "bugs": {
-    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+    "url": "https://github.com/Ani-HQ/cairo/issues"
   },
   "engines": {
     "node": ">=18"
@@ -43,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/outcome-driven-studio/cairo.git",
+    "url": "git+https://github.com/Ani-HQ/cairo.git",
     "directory": "packages/agent-tracker"
   }
 }

--- a/packages/cairo-mcp/package.json
+++ b/packages/cairo-mcp/package.json
@@ -10,9 +10,9 @@
     "index.js",
     "README.md"
   ],
-  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/cairo-mcp",
+  "homepage": "https://github.com/Ani-HQ/cairo/tree/main/packages/cairo-mcp",
   "bugs": {
-    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+    "url": "https://github.com/Ani-HQ/cairo/issues"
   },
   "engines": {
     "node": ">=18"
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/outcome-driven-studio/cairo.git",
+    "url": "git+https://github.com/Ani-HQ/cairo.git",
     "directory": "packages/cairo-mcp"
   }
 }

--- a/packages/cairo-relay/package.json
+++ b/packages/cairo-relay/package.json
@@ -11,9 +11,9 @@
     "README.md",
     "deploy/"
   ],
-  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/cairo-relay",
+  "homepage": "https://github.com/Ani-HQ/cairo/tree/main/packages/cairo-relay",
   "bugs": {
-    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+    "url": "https://github.com/Ani-HQ/cairo/issues"
   },
   "engines": {
     "node": ">=18"
@@ -38,7 +38,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/outcome-driven-studio/cairo.git",
+    "url": "git+https://github.com/Ani-HQ/cairo.git",
     "directory": "packages/cairo-relay"
   }
 }

--- a/packages/tracker/README.md
+++ b/packages/tracker/README.md
@@ -1,6 +1,6 @@
 # @ani-hq/tracker
 
-Universal Segment-style event tracking SDK for [Cairo](https://github.com/outcome-driven-studio/cairo).
+Universal Segment-style event tracking SDK for [Cairo](https://github.com/Ani-HQ/cairo).
 
 ```bash
 npm install @ani-hq/tracker

--- a/packages/tracker/package.json
+++ b/packages/tracker/package.json
@@ -8,9 +8,9 @@
     "dist",
     "README.md"
   ],
-  "homepage": "https://github.com/outcome-driven-studio/cairo/tree/main/packages/tracker",
+  "homepage": "https://github.com/Ani-HQ/cairo/tree/main/packages/tracker",
   "bugs": {
-    "url": "https://github.com/outcome-driven-studio/cairo/issues"
+    "url": "https://github.com/Ani-HQ/cairo/issues"
   },
   "engines": {
     "node": ">=18"
@@ -43,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/outcome-driven-studio/cairo.git",
+    "url": "git+https://github.com/Ani-HQ/cairo.git",
     "directory": "packages/tracker"
   }
 }

--- a/src/routes/docsRoutes.js
+++ b/src/routes/docsRoutes.js
@@ -286,7 +286,7 @@ ${toolSections}
 
 <h2 id="selfhost">Self-hosting</h2>
 <p>Cairo is Node.js + PostgreSQL. MIT licensed.</p>
-<pre>git clone https://github.com/outcome-driven-studio/cairo.git
+<pre>git clone https://github.com/Ani-HQ/cairo.git
 cd cairo
 npm install
 cp .env.example .env
@@ -295,7 +295,7 @@ npm run migrate
 npm start</pre>
 
 <hr>
-<p class="muted">Source: <a href="https://github.com/outcome-driven-studio/cairo">github.com/outcome-driven-studio/cairo</a></p>
+<p class="muted">Source: <a href="https://github.com/Ani-HQ/cairo">github.com/Ani-HQ/cairo</a></p>
 
 </body>
 </html>`;


### PR DESCRIPTION
## Summary
- Repository transferred to https://github.com/Ani-HQ/cairo
- Update all clone URLs, package `repository`/`homepage`/`bugs`, and docs

## Test plan
- [x] Confirm no remaining `outcome-driven-studio` refs
- [ ] Confirm GitHub redirects from old org URL


Made with [Cursor](https://cursor.com)